### PR TITLE
build: Add CMake files for crashpad

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,5 @@
 /third_party/linux/sysroot
 /third_party/lss/lss
 /third_party/gyp/gyp
-/third_party/zlib/zlib
 /xcodebuild
 tags

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@
 /third_party/linux/sysroot
 /third_party/lss/lss
 /third_party/gyp/gyp
-/third_party/mini_chromium/mini_chromium
 /third_party/zlib/zlib
 /xcodebuild
 tags

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "third_party/mini_chromium/mini_chromium"]
 	path = third_party/mini_chromium/mini_chromium
 	url = https://chromium.googlesource.com/chromium/mini_chromium
+[submodule "third_party/zlib/zlib"]
+	path = third_party/zlib/zlib
+	url = https://chromium.googlesource.com/chromium/src/third_party/zlib

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/mini_chromium/mini_chromium"]
+	path = third_party/mini_chromium/mini_chromium
+	url = https://chromium.googlesource.com/chromium/mini_chromium

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.0)
 project(crashpad LANGUAGES C CXX)
 
+if(WIN32)
+    enable_language(ASM_MASM)
+else()
+    enable_language(ASM)
+endif()
+
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
@@ -35,6 +41,28 @@ if(NOT LINUX AND NOT ANDROID)
     include_directories(SYSTEM "compat/non_elf")
 endif()
 
+if(WIN32)
+    add_definitions(
+        /DNOMINMAX
+        /DUNICODE
+        /DWIN32_LEAN_AND_MEAN
+        /D_CRT_SECURE_NO_WARNINGS
+        /D_HAS_EXCEPTIONS=0
+        /D_UNICODE
+        /FS
+        /W4
+        /WX
+        /Zi
+        /bigobj # Support larger number of sections in obj file.
+        /wd4100 # Unreferenced formal parameter.
+        /wd4127 # Conditional expression is constant.
+        /wd4324 # Structure was padded due to alignment specifier.
+        /wd4351 # New behavior: elements of array will be default initialized.
+        /wd4577 # 'noexcept' used with no exception handling mode specified.
+        /wd4996 # 'X' was declared deprecated.
+    )
+endif()
+
 add_subdirectory(client)
 add_subdirectory(compat)
 add_subdirectory(handler)
@@ -43,3 +71,8 @@ add_subdirectory(snapshot)
 add_subdirectory(tools)
 add_subdirectory(util)
 add_subdirectory(third_party/mini_chromium)
+
+if(WIN32)
+    add_subdirectory(third_party/getopt)
+    add_subdirectory(third_party/zlib)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.0)
+project(crashpad LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(LINUX TRUE)
+endif()
+
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/third_party/mini_chromium/mini_chromium")
+
+# These should really be in `compat`, but we want them for the whole project
+if(APPLE)
+    include_directories(SYSTEM "compat/mac")
+else()
+    include_directories(PUBLIC "compat/non_mac")
+endif()
+
+if(LINUX OR ANDROID)
+    include_directories(SYSTEM "compat/linux")
+endif()
+if(ANDROID)
+    include_directories(SYSTEM "compat/android")
+endif()
+
+if(WIN32)
+    include_directories(SYSTEM "compat/win")
+else()
+    include_directories(PUBLIC "compat/non_win")
+endif()
+
+if(NOT LINUX AND NOT ANDROID)
+    include_directories(SYSTEM "compat/non_elf")
+endif()
+
+add_subdirectory(client)
+add_subdirectory(compat)
+add_subdirectory(handler)
+add_subdirectory(minidump)
+add_subdirectory(snapshot)
+add_subdirectory(tools)
+add_subdirectory(util)
+add_subdirectory(third_party/mini_chromium)

--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,22 @@ PATH := $(PWD)/../depot_tools:$(PATH)
 all:
 	echo 'Nothing to do' && exit 1
 
-build:
+build-with-gn:
 	gn gen out/Default
 	ninja -C out/Default
-.PHONY: build
+.PHONY: build-with-gn
 
-update:
+build-with-cmake:
+	mkdir -p cmakebuild
+	cd cmakebuild; cmake ..
+	cmake --build cmakebuild --parallel
+.PHONY: build-with-cmake
+
+update-with-gclient:
 	gclient sync
+.PHONY: update-with-gclient
 
-example:
+example: build-with-gn
 	g++ -g \
 		-o example example.cpp \
 		-I. -I./third_party/mini_chromium/mini_chromium \

--- a/README.getsentry.md
+++ b/README.getsentry.md
@@ -1,3 +1,13 @@
+# Sentry Modifications
+
+- File attachments support for MacOS and Windows. Based on changes made in
+  https://github.com/Youw/crashpad/, distributed with Apache 2.0 License.
+- Add `throws` declaration to `memfd_create` for compatibility with different
+  libc versions.
+- Build System Changes Listed Below
+
+# Build System Changes
+
 In order to minimize external dependencies, and to better integrate with
 `sentry-native`, this fork replaced usage of `depo_tools` with explicit
 submodules, and added CMake files for building.
@@ -36,3 +46,9 @@ included files):
 
 The important thing here is to keep the list of source files in sync when
 updating.
+
+# How To Update
+
+- Bump the submodules to the commit hashes specified in `./DEPS`
+- Go through the changes in `BUILD.gn` files, and apply them to the
+  corresponding `CMakeLists.txt`. See the list above.

--- a/README.getsentry.md
+++ b/README.getsentry.md
@@ -1,0 +1,38 @@
+In order to minimize external dependencies, and to better integrate with
+`sentry-native`, this fork replaced usage of `depo_tools` with explicit
+submodules, and added CMake files for building.
+
+Both submodules and CMake files currently only support building on macOS and
+Windows, and do only export the necessary libraries and executables to
+integrate the crashpad client.
+
+When updating this fork, make sure to keep the files in sync, as explained
+below.
+
+## Submodules
+
+For macOS and Windows support, only `third_party/mini_chromium` and
+`third_party/zlib` are needed.
+
+The specific submodule commit hashes can be found in the `./DEPS` file.
+
+## CMake Integration
+
+To allow building crashpad with CMake, the following CMake files were created
+by manually translating the `BUILD.gn` files in the same folders (and following
+included files):
+
+- `./CMakeLists.txt`
+- `./client/CMakeLists.txt`
+- `./compat/CMakeLists.txt`
+- `./handler/CMakeLists.txt`
+- `./minidump/CMakeLists.txt`
+- `./snapshot/CMakeLists.txt`
+- `./third_party/getopt/CMakeLists.txt`
+- `./third_party/mini_chromium/CMakeLists.txt`
+- `./third_party/lib/CMakeLists.txt`
+- `./tools/CMakeLists.txt`
+- `./util/CMakeLists.txt`
+
+The important thing here is to keep the list of source files in sync when
+updating.

--- a/README.md
+++ b/README.md
@@ -50,3 +50,6 @@ Based on changes made in https://github.com/Youw/crashpad/, distributed with Apa
 Generating patch:
 
     git format-patch --stdout master...HEAD > getsentry.patch
+
+See also [README.getsentry.md](README.getsentry.md) for more information on the
+build system changes, and on how to maintain this fork.

--- a/README.md
+++ b/README.md
@@ -43,13 +43,9 @@ https://chromium.googlesource.com/crashpad/crashpad.
 
 ## Sentry modifications
 
-File attachments support for MacOS and Windows.
-
-Based on changes made in https://github.com/Youw/crashpad/, distributed with Apache 2.0 License.
+See [README.getsentry.md](README.getsentry.md) for more information on the
+changes, and on maintaining the fork.
 
 Generating patch:
 
     git format-patch --stdout master...HEAD > getsentry.patch
-
-See also [README.getsentry.md](README.getsentry.md) for more information on the
-build system changes, and on how to maintain this fork.

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,0 +1,58 @@
+list(APPEND CLIENT_SOURCES
+    annotation.cc
+    annotation.h
+    annotation_list.cc
+    annotation_list.h
+    crash_report_database.cc
+    crash_report_database.h
+    crashpad_client.h
+    crashpad_info.cc
+    crashpad_info.h
+    prune_crash_reports.cc
+    prune_crash_reports.h
+    settings.cc
+    settings.h
+    simple_address_range_bag.h
+    simple_string_dictionary.h
+    simulate_crash.h
+)
+
+if(APPLE)
+    list(APPEND CLIENT_SOURCES
+        crash_report_database_mac.mm
+        crashpad_client_mac.cc
+        simulate_crash_mac.cc
+        simulate_crash_mac.h
+    )
+endif()
+
+if(LINUX OR ANDROID)
+    list(APPEND CLIENT_SOURCES
+      crashpad_client_linux.cc
+      simulate_crash_linux.h
+      client_argv_handling.cc
+      client_argv_handling.h
+      crashpad_info_note.S
+      crash_report_database_generic.cc
+    )
+endif()
+
+if(WIN32)
+    list(APPEND CLIENT_SOURCES
+      crash_report_database_win.cc
+      crashpad_client_win.cc
+      simulate_crash_win.h
+    )
+endif()
+
+add_library(crashpad_client STATIC ${CLIENT_SOURCES})
+target_link_libraries(crashpad_client
+    crashpad_compat
+    crashpad_util
+    mini_chromium
+)
+
+if(WIN32)
+    target_link_libraries(crashpad_client "rpcrt4")
+    target_compile_options(crashpad_client PUBLIC "/wd4201")
+endif()

--- a/compat/CMakeLists.txt
+++ b/compat/CMakeLists.txt
@@ -1,0 +1,85 @@
+list(APPEND COMPAT_SOURCES "")
+
+if(APPLE)
+    list(APPEND COMPAT_SOURCES
+        mac/AvailabilityMacros.h
+        mac/kern/exc_resource.h
+        mac/mach-o/loader.h
+        mac/mach/mach.h
+        mac/sys/resource.h
+    )
+else()
+    list(APPEND COMPAT_SOURCES
+        non_mac/mach-o/loader.h
+        non_mac/mach/mach.h
+        non_mac/mach/machine.h
+        non_mac/mach/vm_prot.h
+    )
+endif()
+
+if(LINUX OR ANDROID)
+    list(APPEND COMPAT_SOURCES
+        linux/signal.h
+        linux/sys/mman.cc
+        linux/sys/mman.h
+        linux/sys/ptrace.h
+        linux/sys/user.h
+    )
+endif()
+
+if(ANDROID)
+    list(APPEND COMPAT_SOURCES
+        android/android/api-level.cc
+        android/android/api-level.h
+        android/dlfcn_internal.cc
+        android/dlfcn_internal.h
+        android/elf.h
+        android/linux/elf.h
+        android/linux/prctl.h
+        android/linux/ptrace.h
+        android/sched.h
+        android/sys/epoll.cc
+        android/sys/epoll.h
+        android/sys/mman.cc
+        android/sys/mman.h
+        android/sys/syscall.h
+        android/sys/user.h
+    )
+endif()
+
+if(WIN32)
+    list(APPEND COMPAT_SOURCES
+        win/getopt.h
+        win/strings.cc
+        win/strings.h
+        win/sys/types.h
+        win/time.cc
+        win/time.h
+        win/winbase.h
+        win/winnt.h
+        win/winternl.h
+    )
+else()
+    list(APPEND COMPAT_SOURCES
+        non_win/dbghelp.h
+        non_win/minwinbase.h
+        non_win/timezoneapi.h
+        non_win/verrsrc.h
+        non_win/windows.h
+        non_win/winnt.h
+    )
+endif()
+
+if(NOT LINUX AND NOT ANDROID)
+    list(APPEND COMPAT_SOURCES
+        non_elf/elf.h
+    )
+endif()
+
+if(APPLE)
+    add_library(crashpad_compat INTERFACE)
+    list(TRANSFORM COMPAT_SOURCES PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
+    target_sources(crashpad_compat INTERFACE ${COMPAT_SOURCES})
+else()
+    add_library(crashpad_compat STATIC ${COMPAT_SOURCES})
+endif()

--- a/compat/CMakeLists.txt
+++ b/compat/CMakeLists.txt
@@ -83,3 +83,7 @@ if(APPLE)
 else()
     add_library(crashpad_compat STATIC ${COMPAT_SOURCES})
 endif()
+
+if(WIN32)
+    target_link_libraries(crashpad_compat getopt)
+endif()

--- a/handler/CMakeLists.txt
+++ b/handler/CMakeLists.txt
@@ -1,0 +1,63 @@
+list(APPEND HANDLER_SOURCES
+    main.cc
+    crash_report_upload_thread.cc
+    crash_report_upload_thread.h
+    handler_main.cc
+    handler_main.h
+    minidump_to_upload_parameters.cc
+    minidump_to_upload_parameters.h
+    prune_crash_reports_thread.cc
+    prune_crash_reports_thread.h
+    user_stream_data_source.cc
+    user_stream_data_source.h
+)
+
+if(APPLE)
+    list(APPEND HANDLER_SOURCES
+        mac/crash_report_exception_handler.cc
+        mac/crash_report_exception_handler.h
+        mac/exception_handler_server.cc
+        mac/exception_handler_server.h
+        mac/file_limit_annotation.cc
+        mac/file_limit_annotation.h
+    )
+endif()
+
+if(LINUX OR ANDROID)
+    list(APPEND HANDLER_SOURCES
+        linux/capture_snapshot.cc
+        linux/capture_snapshot.h
+        linux/crash_report_exception_handler.cc
+        linux/crash_report_exception_handler.h
+        linux/exception_handler_server.cc
+        linux/exception_handler_server.h
+    )
+endif()
+
+if(LINUX)
+    list(APPEND HANDLER_SOURCES
+        linux/cros_crash_report_exception_handler.cc
+        linux/cros_crash_report_exception_handler.h
+    )
+endif()
+
+if(WIN32)
+    list(APPEND HANDLER_SOURCES
+        win/crash_report_exception_handler.cc
+        win/crash_report_exception_handler.h
+    )
+endif()
+
+add_executable(crashpad_handler ${HANDLER_SOURCES})
+target_link_libraries(crashpad_handler
+    crashpad_client
+    crashpad_minidump
+    crashpad_snapshot
+    crashpad_tools
+    crashpad_util
+    mini_chromium
+)
+
+if(WIN32)
+    target_compile_options(crashpad_handler PUBLIC "/wd4201")
+endif()

--- a/minidump/CMakeLists.txt
+++ b/minidump/CMakeLists.txt
@@ -1,0 +1,65 @@
+list(APPEND MINIDUMP_SOURCES
+    minidump_annotation_writer.cc
+    minidump_annotation_writer.h
+    minidump_byte_array_writer.cc
+    minidump_byte_array_writer.h
+    minidump_context.h
+    minidump_context_writer.cc
+    minidump_context_writer.h
+    minidump_crashpad_info_writer.cc
+    minidump_crashpad_info_writer.h
+    minidump_exception_writer.cc
+    minidump_exception_writer.h
+    minidump_extensions.cc
+    minidump_extensions.h
+    minidump_file_writer.cc
+    minidump_file_writer.h
+    minidump_handle_writer.cc
+    minidump_handle_writer.h
+    minidump_memory_info_writer.cc
+    minidump_memory_info_writer.h
+    minidump_memory_writer.cc
+    minidump_memory_writer.h
+    minidump_misc_info_writer.cc
+    minidump_misc_info_writer.h
+    minidump_module_crashpad_info_writer.cc
+    minidump_module_crashpad_info_writer.h
+    minidump_module_writer.cc
+    minidump_module_writer.h
+    minidump_rva_list_writer.cc
+    minidump_rva_list_writer.h
+    minidump_simple_string_dictionary_writer.cc
+    minidump_simple_string_dictionary_writer.h
+    minidump_stream_writer.cc
+    minidump_stream_writer.h
+    minidump_string_writer.cc
+    minidump_string_writer.h
+    minidump_system_info_writer.cc
+    minidump_system_info_writer.h
+    minidump_thread_id_map.cc
+    minidump_thread_id_map.h
+    minidump_thread_writer.cc
+    minidump_thread_writer.h
+    minidump_unloaded_module_writer.cc
+    minidump_unloaded_module_writer.h
+    minidump_user_extension_stream_data_source.cc
+    minidump_user_extension_stream_data_source.h
+    minidump_user_stream_writer.cc
+    minidump_user_stream_writer.h
+    minidump_writable.cc
+    minidump_writable.h
+    minidump_writer_util.cc
+    minidump_writer_util.h
+)
+
+add_library(crashpad_minidump STATIC ${MINIDUMP_SOURCES})
+target_link_libraries(crashpad_minidump
+    crashpad_compat
+    crashpad_snapshot
+    crashpad_util
+    mini_chromium
+)
+
+if(WIN32)
+    target_compile_options(crashpad_minidump PUBLIC "/wd4201" "/wd4324")
+endif()

--- a/snapshot/CMakeLists.txt
+++ b/snapshot/CMakeLists.txt
@@ -1,0 +1,181 @@
+list(APPEND SNAPSHOT_SOURCES
+    annotation_snapshot.cc
+    annotation_snapshot.h
+    capture_memory.cc
+    capture_memory.h
+    cpu_architecture.h
+    cpu_context.cc
+    cpu_context.h
+    crashpad_info_client_options.cc
+    crashpad_info_client_options.h
+    exception_snapshot.h
+    handle_snapshot.cc
+    handle_snapshot.h
+    memory_snapshot.cc
+    memory_snapshot.h
+    memory_snapshot_generic.h
+    minidump/exception_snapshot_minidump.cc
+    minidump/exception_snapshot_minidump.h
+    minidump/memory_snapshot_minidump.cc
+    minidump/memory_snapshot_minidump.h
+    minidump/minidump_annotation_reader.cc
+    minidump/minidump_annotation_reader.h
+    minidump/minidump_context_converter.cc
+    minidump/minidump_context_converter.h
+    minidump/minidump_simple_string_dictionary_reader.cc
+    minidump/minidump_simple_string_dictionary_reader.h
+    minidump/minidump_stream.h
+    minidump/minidump_string_list_reader.cc
+    minidump/minidump_string_list_reader.h
+    minidump/minidump_string_reader.cc
+    minidump/minidump_string_reader.h
+    minidump/module_snapshot_minidump.cc
+    minidump/module_snapshot_minidump.h
+    minidump/process_snapshot_minidump.cc
+    minidump/process_snapshot_minidump.h
+    minidump/system_snapshot_minidump.cc
+    minidump/system_snapshot_minidump.h
+    minidump/thread_snapshot_minidump.cc
+    minidump/thread_snapshot_minidump.h
+    module_snapshot.h
+    process_snapshot.h
+    snapshot_constants.h
+    system_snapshot.h
+    thread_snapshot.h
+    unloaded_module_snapshot.cc
+    unloaded_module_snapshot.h
+)
+
+
+if(APPLE)
+    list(APPEND SNAPSHOT_SOURCES
+        posix/timezone.cc
+        posix/timezone.h
+        mac/cpu_context_mac.cc
+        mac/cpu_context_mac.h
+        mac/exception_snapshot_mac.cc
+        mac/exception_snapshot_mac.h
+        mac/mach_o_image_annotations_reader.cc
+        mac/mach_o_image_annotations_reader.h
+        mac/mach_o_image_reader.cc
+        mac/mach_o_image_reader.h
+        mac/mach_o_image_segment_reader.cc
+        mac/mach_o_image_segment_reader.h
+        mac/mach_o_image_symbol_table_reader.cc
+        mac/mach_o_image_symbol_table_reader.h
+        mac/module_snapshot_mac.cc
+        mac/module_snapshot_mac.h
+        mac/process_reader_mac.cc
+        mac/process_reader_mac.h
+        mac/process_snapshot_mac.cc
+        mac/process_snapshot_mac.h
+        mac/process_types.cc
+        mac/process_types.h
+        mac/process_types/custom.cc
+        mac/process_types/flavors.h
+        mac/process_types/internal.h
+        mac/process_types/traits.h
+        mac/system_snapshot_mac.cc
+        mac/system_snapshot_mac.h
+        mac/thread_snapshot_mac.cc
+        mac/thread_snapshot_mac.h
+    )
+else()
+    list(APPEND SNAPSHOT_SOURCES
+        crashpad_types/crashpad_info_reader.cc
+        crashpad_types/crashpad_info_reader.h
+    )
+endif()
+
+if(LINUX OR ANDROID)
+    list(APPEND SNAPSHOT_SOURCES
+        posix/timezone.cc
+        posix/timezone.h
+        linux/cpu_context_linux.cc
+        linux/cpu_context_linux.h
+        linux/debug_rendezvous.cc
+        linux/debug_rendezvous.h
+        linux/exception_snapshot_linux.cc
+        linux/exception_snapshot_linux.h
+        linux/process_reader_linux.cc
+        linux/process_reader_linux.h
+        linux/process_snapshot_linux.cc
+        linux/process_snapshot_linux.h
+        linux/signal_context.h
+        linux/system_snapshot_linux.cc
+        linux/system_snapshot_linux.h
+        linux/thread_snapshot_linux.cc
+        linux/thread_snapshot_linux.h
+        sanitized/memory_snapshot_sanitized.cc
+        sanitized/memory_snapshot_sanitized.h
+        sanitized/module_snapshot_sanitized.cc
+        sanitized/module_snapshot_sanitized.h
+        sanitized/process_snapshot_sanitized.cc
+        sanitized/process_snapshot_sanitized.h
+        sanitized/sanitization_information.cc
+        sanitized/sanitization_information.h
+        sanitized/thread_snapshot_sanitized.cc
+        sanitized/thread_snapshot_sanitized.h
+        crashpad_types/image_annotation_reader.cc
+        crashpad_types/image_annotation_reader.h
+        elf/elf_dynamic_array_reader.cc
+        elf/elf_dynamic_array_reader.h
+        elf/elf_image_reader.cc
+        elf/elf_image_reader.h
+        elf/elf_symbol_table_reader.cc
+        elf/elf_symbol_table_reader.h
+        elf/module_snapshot_elf.cc
+        elf/module_snapshot_elf.h
+    )
+endif()
+
+if(WIN32)
+    list(APPEND SNAPSHOT_SOURCES
+        win/capture_memory_delegate_win.cc
+        win/capture_memory_delegate_win.h
+        win/cpu_context_win.cc
+        win/cpu_context_win.h
+        win/exception_snapshot_win.cc
+        win/exception_snapshot_win.h
+        win/memory_map_region_snapshot_win.cc
+        win/memory_map_region_snapshot_win.h
+        win/module_snapshot_win.cc
+        win/module_snapshot_win.h
+        win/pe_image_annotations_reader.cc
+        win/pe_image_annotations_reader.h
+        win/pe_image_reader.cc
+        win/pe_image_reader.h
+        win/pe_image_resource_reader.cc
+        win/pe_image_resource_reader.h
+        win/process_reader_win.cc
+        win/process_reader_win.h
+        win/process_snapshot_win.cc
+        win/process_snapshot_win.h
+        win/process_subrange_reader.cc
+        win/process_subrange_reader.h
+        win/system_snapshot_win.cc
+        win/system_snapshot_win.h
+        win/thread_snapshot_win.cc
+        win/thread_snapshot_win.h
+    )
+endif()
+
+# TODO: if(x86)
+    list(APPEND SNAPSHOT_SOURCES
+        x86/cpuid_reader.cc
+        x86/cpuid_reader.h
+    )
+#endif()
+
+add_library(crashpad_snapshot STATIC ${SNAPSHOT_SOURCES})
+target_link_libraries(crashpad_snapshot
+    crashpad_client
+    crashpad_compat
+    crashpad_util
+    mini_chromium
+)
+
+if(WIN32)
+    target_link_libraries(crashpad_snapshot "powrprof")
+    target_compile_options(crashpad_snapshot PUBLIC "/wd4201")
+endif()

--- a/third_party/getopt/CMakeLists.txt
+++ b/third_party/getopt/CMakeLists.txt
@@ -1,0 +1,6 @@
+list(APPEND GETOPT_SOURCES
+    getopt.cc
+    getopt.h
+)
+
+add_library(getopt STATIC ${GETOPT_SOURCES})

--- a/third_party/mini_chromium/CMakeLists.txt
+++ b/third_party/mini_chromium/CMakeLists.txt
@@ -123,6 +123,14 @@ if(APPLE)
 endif()
 
 if(WIN32)
-    target_link_libraries(mini_chromium "advapi32")
-    target_compile_options(mini_chromium PUBLIC "/wd4201")
+    target_link_libraries(mini_chromium "advapi32" "kernel32")
+    target_compile_options(mini_chromium PUBLIC "/wd4201" "/wd4996")
+    target_compile_definitions(mini_chromium PUBLIC
+        NOMINMAX
+        UNICODE
+        WIN32_LEAN_AND_MEAN
+        _CRT_SECURE_NO_WARNINGS
+        _HAS_EXCEPTIONS=0
+        _UNICODE
+    )
 endif()

--- a/third_party/mini_chromium/CMakeLists.txt
+++ b/third_party/mini_chromium/CMakeLists.txt
@@ -1,0 +1,128 @@
+list(APPEND MINI_CHROMIUM_SOURCES
+    ../build/build_config.h
+    atomicops.h
+    atomicops_internals_atomicword_compat.h
+    atomicops_internals_portable.h
+    auto_reset.h
+    bit_cast.h
+    compiler_specific.h
+    debug/alias.cc
+    debug/alias.h
+    files/file_path.cc
+    files/file_path.h
+    files/file_util.h
+    files/scoped_file.cc
+    files/scoped_file.h
+    format_macros.h
+    logging.cc
+    logging.h
+    macros.h
+    memory/free_deleter.h
+    memory/scoped_policy.h
+    metrics/histogram_functions.h
+    metrics/histogram_macros.h
+    metrics/persistent_histogram_allocator.h
+    numerics/checked_math.h
+    numerics/checked_math_impl.h
+    numerics/clamped_math.h
+    numerics/clamped_math_impl.h
+    numerics/safe_conversions.h
+    numerics/safe_conversions_arm_impl.h
+    numerics/safe_conversions_impl.h
+    numerics/safe_math.h
+    numerics/safe_math_arm_impl.h
+    numerics/safe_math_clang_gcc_impl.h
+    numerics/safe_math_shared_impl.h
+    process/memory.cc
+    process/memory.h
+    process/process_metrics.h
+    rand_util.cc
+    rand_util.h
+    scoped_clear_errno.h
+    scoped_generic.h
+    stl_util.h
+    strings/string16.cc
+    strings/string16.h
+    strings/string_number_conversions.cc
+    strings/string_number_conversions.h
+    strings/string_piece.h
+    strings/string_util.h
+    strings/stringprintf.cc
+    strings/stringprintf.h
+    strings/sys_string_conversions.h
+    strings/utf_string_conversion_utils.cc
+    strings/utf_string_conversion_utils.h
+    strings/utf_string_conversions.cc
+    strings/utf_string_conversions.h
+    synchronization/condition_variable.h
+    synchronization/lock.cc
+    synchronization/lock.h
+    synchronization/lock_impl.h
+    sys_byteorder.h
+    template_util.h
+    third_party/icu/icu_utf.cc
+    third_party/icu/icu_utf.h
+    threading/thread_local_storage.cc
+    threading/thread_local_storage.h
+)
+
+if(APPLE)
+    list(APPEND MINI_CHROMIUM_SOURCES
+        mac/close_nocancel.cc
+        mac/foundation_util.h
+        mac/foundation_util.mm
+        mac/mach_logging.cc
+        mac/mach_logging.h
+        mac/scoped_cftyperef.h
+        mac/scoped_ioobject.h
+        mac/scoped_launch_data.h
+        mac/scoped_mach_port.cc
+        mac/scoped_mach_port.h
+        mac/scoped_mach_vm.cc
+        mac/scoped_mach_vm.h
+        mac/scoped_nsautorelease_pool.h
+        mac/scoped_nsautorelease_pool.mm
+        mac/scoped_nsobject.h
+        mac/scoped_typeref.h
+        strings/sys_string_conversions_mac.mm
+    )
+endif()
+
+if(WIN32)
+    list(APPEND MINI_CHROMIUM_SOURCES
+        process/process_metrics_win.cc
+        strings/string_util_win.cc
+        strings/string_util_win.h
+        synchronization/lock_impl_win.cc
+        threading/thread_local_storage_win.cc
+    )
+else()
+    list(APPEND MINI_CHROMIUM_SOURCES
+        files/file_util_posix.cc
+        posix/eintr_wrapper.h
+        posix/safe_strerror.cc
+        posix/safe_strerror.h
+        process/process_metrics_posix.cc
+        strings/string_util_posix.h
+        synchronization/condition_variable_posix.cc
+        synchronization/lock_impl_posix.cc
+        threading/thread_local_storage_posix.cc
+    )
+endif()
+
+list(TRANSFORM MINI_CHROMIUM_SOURCES PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/mini_chromium/base/")
+
+add_library(mini_chromium STATIC ${MINI_CHROMIUM_SOURCES})
+
+if(APPLE)
+    target_link_libraries(mini_chromium PUBLIC "-framework ApplicationServices")
+    target_link_libraries(mini_chromium PUBLIC "-framework CoreFoundation")
+    target_link_libraries(mini_chromium PUBLIC "-framework Foundation")
+    target_link_libraries(mini_chromium PUBLIC "-framework IOKit")
+    target_link_libraries(mini_chromium PUBLIC "-framework Security")
+endif()
+
+if(WIN32)
+    target_link_libraries(mini_chromium "advapi32")
+    target_compile_options(mini_chromium PUBLIC "/wd4201")
+endif()

--- a/third_party/zlib/CMakeLists.txt
+++ b/third_party/zlib/CMakeLists.txt
@@ -24,9 +24,9 @@ list(APPEND ZLIB_SOURCES
     zlib/uncompr.c
     zlib/zconf.h
     zlib/zlib.h
-    #zlib/zlib_crashpad.h
     zlib/zutil.c
     zlib/zutil.h
+    zlib_crashpad.h
 )
 
 # TODO: x86/x64

--- a/third_party/zlib/CMakeLists.txt
+++ b/third_party/zlib/CMakeLists.txt
@@ -1,0 +1,54 @@
+list(APPEND ZLIB_SOURCES
+    zlib/adler32.c
+    zlib/compress.c
+    zlib/crc32.c
+    zlib/crc32.h
+    zlib/deflate.c
+    zlib/deflate.h
+    zlib/gzclose.c
+    zlib/gzguts.h
+    zlib/gzlib.c
+    zlib/gzread.c
+    zlib/gzwrite.c
+    zlib/infback.c
+    zlib/inffast.c
+    zlib/inffast.h
+    zlib/inffixed.h
+    zlib/inflate.c
+    zlib/inflate.h
+    zlib/inftrees.c
+    zlib/inftrees.h
+    zlib/names.h
+    zlib/trees.c
+    zlib/trees.h
+    zlib/uncompr.c
+    zlib/zconf.h
+    zlib/zlib.h
+    #zlib/zlib_crashpad.h
+    zlib/zutil.c
+    zlib/zutil.h
+)
+
+# TODO: x86/x64
+list(APPEND ZLIB_SOURCES
+    zlib/crc_folding.c
+    zlib/fill_window_sse.c
+    zlib/x86.c
+    zlib/x86.h
+)
+
+add_library(zlib STATIC ${ZLIB_SOURCES})
+target_compile_definitions(zlib PUBLIC HAVE_STDARG_H)
+
+include_directories(zlib)
+
+if(WIN32)
+    target_compile_options(zlib PUBLIC
+        "/wd4131" # uses old-style declarator
+        "/wd4244" # conversion from 't1' to 't2', possible loss of data
+        "/wd4245" # conversion from 't1' to 't2', signed/unsigned mismatch
+        "/wd4267" # conversion from 'size_t' to 't', possible loss of data
+        "/wd4324" # structure was padded due to alignment specifier
+        "/wd4702" # unreachable code
+    )
+endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,0 +1,11 @@
+list(APPEND TOOLS_SOURCES
+    tool_support.cc
+    tool_support.h
+)
+
+add_library(crashpad_tools STATIC ${TOOLS_SOURCES})
+target_link_libraries(crashpad_tools
+    mini_chromium
+)
+
+# TODO: do we need any tool executables?

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,0 +1,359 @@
+list(APPEND UTIL_SOURCES
+    file/delimited_file_reader.cc
+    file/delimited_file_reader.h
+    file/directory_reader.h
+    file/file_io.cc
+    file/file_io.h
+    file/file_reader.cc
+    file/file_reader.h
+    file/file_seeker.cc
+    file/file_seeker.h
+    file/file_writer.cc
+    file/file_writer.h
+    file/filesystem.h
+    file/scoped_remove_file.cc
+    file/scoped_remove_file.h
+    file/string_file.cc
+    file/string_file.h
+    misc/address_sanitizer.h
+    misc/address_types.h
+    misc/arraysize.h
+    misc/as_underlying_type.h
+    misc/capture_context.h
+    misc/clock.h
+    misc/elf_note_types.h
+    misc/from_pointer_cast.h
+    misc/implicit_cast.h
+    misc/initialization_state.h
+    misc/initialization_state_dcheck.cc
+    misc/initialization_state_dcheck.h
+    misc/lexing.cc
+    misc/lexing.h
+    misc/memory_sanitizer.h
+    misc/metrics.cc
+    misc/metrics.h
+    misc/paths.h
+    misc/pdb_structures.cc
+    misc/pdb_structures.h
+    misc/random_string.cc
+    misc/random_string.h
+    misc/range_set.cc
+    misc/range_set.h
+    misc/reinterpret_bytes.cc
+    misc/reinterpret_bytes.h
+    misc/scoped_forbid_return.cc
+    misc/scoped_forbid_return.h
+    misc/symbolic_constants_common.h
+    misc/time.cc
+    misc/time.h
+    misc/tri_state.h
+    misc/uuid.cc
+    misc/uuid.h
+    misc/zlib.cc
+    misc/zlib.h
+    net/http_body.cc
+    net/http_body.h
+    net/http_body_gzip.cc
+    net/http_body_gzip.h
+    net/http_headers.h
+    net/http_multipart_builder.cc
+    net/http_multipart_builder.h
+    net/http_transport.cc
+    net/http_transport.h
+    net/url.cc
+    net/url.h
+    numeric/checked_address_range.cc
+    numeric/checked_address_range.h
+    numeric/checked_range.h
+    numeric/checked_vm_address_range.h
+    numeric/in_range_cast.h
+    numeric/int128.h
+    numeric/safe_assignment.h
+    process/process_id.h
+    process/process_memory.cc
+    process/process_memory.h
+    process/process_memory_native.h
+    process/process_memory_range.cc
+    process/process_memory_range.h
+    stdlib/aligned_allocator.cc
+    stdlib/aligned_allocator.h
+    stdlib/map_insert.h
+    stdlib/objc.h
+    stdlib/string_number_conversion.cc
+    stdlib/string_number_conversion.h
+    stdlib/strlcpy.cc
+    stdlib/strlcpy.h
+    stdlib/strnlen.cc
+    stdlib/strnlen.h
+    stdlib/thread_safe_vector.h
+    stream/output_stream_interface.h
+    stream/zlib_output_stream.cc
+    stream/zlib_output_stream.h
+    string/split_string.cc
+    string/split_string.h
+    synchronization/semaphore.h
+    thread/stoppable.h
+    thread/thread.cc
+    thread/thread.h
+    thread/thread_log_messages.cc
+    thread/thread_log_messages.h
+    thread/worker_thread.cc
+    thread/worker_thread.h
+)
+
+if(NOT WIN32)
+    list(APPEND UTIL_SOURCES
+        file/directory_reader_posix.cc
+        file/file_io_posix.cc
+        file/filesystem_posix.cc
+        misc/clock_posix.cc
+        posix/close_stdio.cc
+        posix/close_stdio.h
+        posix/scoped_dir.cc
+        posix/scoped_dir.h
+        posix/scoped_mmap.cc
+        posix/scoped_mmap.h
+        posix/signals.cc
+        posix/signals.h
+        synchronization/semaphore_posix.cc
+        thread/thread_posix.cc
+        posix/close_multiple.cc
+        posix/close_multiple.h
+        posix/double_fork_and_exec.cc
+        posix/double_fork_and_exec.h
+        posix/drop_privileges.cc
+        posix/drop_privileges.h
+        posix/process_info.h
+        posix/symbolic_constants_posix.cc
+        posix/symbolic_constants_posix.h
+    )
+endif()
+
+if(APPLE)
+    list(APPEND UTIL_SOURCES
+        mac/checked_mach_address_range.h
+        mac/launchd.h
+        mac/launchd.mm
+        mac/mac_util.cc
+        mac/mac_util.h
+        mac/service_management.cc
+        mac/service_management.h
+        mac/xattr.cc
+        mac/xattr.h
+        mach/child_port_handshake.cc
+        mach/child_port_handshake.h
+        mach/child_port_server.cc
+        mach/child_port_server.h
+        mach/child_port_types.h
+        mach/composite_mach_message_server.cc
+        mach/composite_mach_message_server.h
+        mach/exc_client_variants.cc
+        mach/exc_client_variants.h
+        mach/exc_server_variants.cc
+        mach/exc_server_variants.h
+        mach/exception_behaviors.cc
+        mach/exception_behaviors.h
+        mach/exception_ports.cc
+        mach/exception_ports.h
+        mach/exception_types.cc
+        mach/exception_types.h
+        mach/mach_extensions.cc
+        mach/mach_extensions.h
+        mach/mach_message.cc
+        mach/mach_message.h
+        mach/mach_message_server.cc
+        mach/mach_message_server.h
+        mach/notify_server.cc
+        mach/notify_server.h
+        mach/scoped_task_suspend.cc
+        mach/scoped_task_suspend.h
+        mach/symbolic_constants_mach.cc
+        mach/symbolic_constants_mach.h
+        mach/task_for_pid.cc
+        mach/task_for_pid.h
+        misc/capture_context_mac.S
+        misc/clock_mac.cc
+        misc/paths_mac.cc
+        net/http_transport_mac.mm
+        posix/process_info_mac.cc
+        process/process_memory_mac.cc
+        process/process_memory_mac.h
+        synchronization/semaphore_mac.cc
+    )
+endif()
+
+if(LINUX OR ANDROID)
+    list(APPEND UTIL_SOURCES
+        net/http_transport_socket.cc
+        linux/address_types.h
+        linux/auxiliary_vector.cc
+        linux/auxiliary_vector.h
+        linux/checked_linux_address_range.h
+        linux/direct_ptrace_connection.cc
+        linux/direct_ptrace_connection.h
+        linux/exception_handler_client.cc
+        linux/exception_handler_client.h
+        linux/exception_handler_protocol.cc
+        linux/exception_handler_protocol.h
+        linux/exception_information.h
+        linux/memory_map.cc
+        linux/memory_map.h
+        linux/proc_stat_reader.cc
+        linux/proc_stat_reader.h
+        linux/proc_task_reader.cc
+        linux/proc_task_reader.h
+        linux/ptrace_broker.cc
+        linux/ptrace_broker.h
+        linux/ptrace_client.cc
+        linux/ptrace_client.h
+        linux/ptrace_connection.h
+        linux/ptracer.cc
+        linux/ptracer.h
+        linux/scoped_pr_set_dumpable.cc
+        linux/scoped_pr_set_dumpable.h
+        linux/scoped_pr_set_ptracer.cc
+        linux/scoped_pr_set_ptracer.h
+        linux/scoped_ptrace_attach.cc
+        linux/scoped_ptrace_attach.h
+        linux/socket.cc
+        linux/socket.h
+        linux/thread_info.cc
+        linux/thread_info.h
+        linux/traits.h
+        misc/capture_context_linux.S
+        misc/paths_linux.cc
+        posix/process_info_linux.cc
+        process/process_memory_linux.cc
+        process/process_memory_linux.h
+        process/process_memory_sanitized.cc
+        process/process_memory_sanitized.h
+    )
+endif()
+
+if(WIN32)
+    list(APPEND UTIL_SOURCES
+        file/directory_reader_win.cc
+        file/file_io_win.cc
+        file/filesystem_win.cc
+        misc/clock_win.cc
+        misc/paths_win.cc
+        misc/time_win.cc
+        net/http_transport_win.cc
+        process/process_memory_win.cc
+        process/process_memory_win.h
+        synchronization/semaphore_win.cc
+        thread/thread_win.cc
+        win/address_types.h
+        win/checked_win_address_range.h
+        win/command_line.cc
+        win/command_line.h
+        win/context_wrappers.h
+        win/critical_section_with_debug_info.cc
+        win/critical_section_with_debug_info.h
+        win/exception_handler_server.cc
+        win/exception_handler_server.h
+        win/get_function.cc
+        win/get_function.h
+        win/get_module_information.cc
+        win/get_module_information.h
+        win/handle.cc
+        win/handle.h
+        win/initial_client_data.cc
+        win/initial_client_data.h
+        win/module_version.cc
+        win/module_version.h
+        win/nt_internals.cc
+        win/nt_internals.h
+        win/ntstatus_logging.cc
+        win/ntstatus_logging.h
+        win/process_info.cc
+        win/process_info.h
+        win/process_structs.h
+        win/registration_protocol_win.cc
+        win/registration_protocol_win.h
+        win/safe_terminate_process.h
+        win/scoped_handle.cc
+        win/scoped_handle.h
+        win/scoped_local_alloc.cc
+        win/scoped_local_alloc.h
+        win/scoped_process_suspend.cc
+        win/scoped_process_suspend.h
+        win/scoped_set_event.cc
+        win/scoped_set_event.h
+        win/session_end_watcher.cc
+        win/session_end_watcher.h
+        win/termination_codes.h
+        win/xp_compat.h
+    )
+endif()
+
+# Copied from: https://github.com/qedsoftware/crashpad/blob/3583c50a6575857abcf140f6ea3b8d11390205b3/util/CMakeLists.txt#L196-L233
+if(APPLE)
+  set(def_relative_files "exc.defs" "mach_exc.defs" "notify.defs")
+  set(input_files "")
+  foreach(x ${def_relative_files})
+    # CMAKE_OSX_SYSROOT may be empty (e.g. for Makefile generators),
+    # in this case files will be taken from root.
+    set(full_path "${CMAKE_OSX_SYSROOT}/usr/include/mach/${x}")
+    if(NOT EXISTS "${full_path}")
+      message(FATAL_ERROR "File not found: ${full_path}")
+    endif()
+    list(APPEND input_files "${full_path}")
+  endforeach()
+  list(APPEND input_files "${CMAKE_CURRENT_LIST_DIR}/mach/child_port.defs")
+
+  find_package(PythonInterp 2.7 REQUIRED)
+
+  set(output_dir "${CMAKE_CURRENT_BINARY_DIR}/util/mach")
+  file(MAKE_DIRECTORY "${output_dir}")
+
+  # Create generate rule for each input file. Add each generated output
+  # as a source to the target.
+  foreach(input ${input_files})
+    get_filename_component(name_we "${input}" NAME_WE)
+    set(output_files "")
+    foreach(suffix "User.c" "Server.c" ".h" "Server.h")
+      list(APPEND output_files "${output_dir}/${name_we}${suffix}")
+    endforeach()
+    add_custom_command(
+        OUTPUT
+        ${output_files}
+        COMMAND
+        "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mach/mig.py" "${input}" ${output_files}
+        DEPENDS
+        "${CMAKE_CURRENT_SOURCE_DIR}/mach/mig.py" "${input}"
+    )
+    list(APPEND UTIL_SOURCES ${output_files})
+  endforeach()
+
+  include_directories("${CMAKE_CURRENT_BINARY_DIR}")
+endif()
+
+add_library(crashpad_util STATIC ${UTIL_SOURCES})
+target_link_libraries(crashpad_util PUBLIC
+    crashpad_compat
+    mini_chromium
+)
+
+target_compile_definitions(crashpad_util PUBLIC "-DZLIB_CONST")
+
+if(WIN32)
+    # TODO:
+    #target_compile_definitions(crashpad_util PUBLIC "-DCRASHPAD_ZLIB_SOURCE_EXTERNAL")
+    #target_link_libraries(crashpad_util PUBLIC zlib)
+else()
+    target_compile_definitions(crashpad_util PUBLIC "-DCRASHPAD_ZLIB_SOURCE_SYSTEM")
+    target_link_libraries(crashpad_util PUBLIC "z")
+endif()
+
+if(APPLE)
+    target_link_libraries(crashpad_util PUBLIC "bsm")
+    target_link_libraries(crashpad_util PUBLIC "-framework CoreFoundation")
+    target_link_libraries(crashpad_util PUBLIC "-framework Foundation")
+    target_link_libraries(crashpad_util PUBLIC "-framework IOKit")
+endif()
+
+if(WIN32)
+    target_link_libraries(crashpad_util PUBLIC "user32" "version" "winhttp")
+    target_compile_options(crashpad_util PUBLIC "/wd4201")
+endif()

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -284,6 +284,9 @@ if(WIN32)
         win/session_end_watcher.h
         win/termination_codes.h
         win/xp_compat.h
+
+        misc/capture_context_win.asm
+        win/safe_terminate_process.asm
     )
 endif()
 
@@ -338,9 +341,8 @@ target_link_libraries(crashpad_util PUBLIC
 target_compile_definitions(crashpad_util PUBLIC "-DZLIB_CONST")
 
 if(WIN32)
-    # TODO:
-    #target_compile_definitions(crashpad_util PUBLIC "-DCRASHPAD_ZLIB_SOURCE_EXTERNAL")
-    #target_link_libraries(crashpad_util PUBLIC zlib)
+    target_compile_definitions(crashpad_util PUBLIC "-DCRASHPAD_ZLIB_SOURCE_EMBEDDED")
+    target_link_libraries(crashpad_util PUBLIC zlib)
 else()
     target_compile_definitions(crashpad_util PUBLIC "-DCRASHPAD_ZLIB_SOURCE_SYSTEM")
     target_link_libraries(crashpad_util PUBLIC "z")


### PR DESCRIPTION
This adds CMake files for crashpad, and also consumes `mini_chromium` via a submodule instead of relying on `repo_tools`.