### PR TITLE
win: Make crashpad_handler a GUI app

### DIFF
--- a/handler/CMakeLists.txt
+++ b/handler/CMakeLists.txt
@@ -65,6 +65,7 @@ target_link_libraries(crashpad_handler
 if(WIN32) 
     if(MSVC)
         target_compile_options(crashpad_handler PUBLIC "/wd4201")
+        target_link_options(crashpad_handler PUBLIC "/SUBSYSTEM:WINDOWS")
     endif()
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         target_compile_options(crashpad_handler PRIVATE 


### PR DESCRIPTION
This change adds a missing `/SUBSYSTEM:WINDOWS` option to the linker command line on Windows for the `crashpad_handler.exe` binary. Without this option (which the regular Crashpad build system [also adds](https://github.com/getsentry/crashpad/blob/getsentry/handler/handler.gyp#L90)) the resulting executable will open an empty console window on startup, which is particularly unsightly for Windows GUI applications integrating `sentry-native` which would otherwise have no console windows.