### PR TITLE
cmake: use targets (includes/definitions/... + add install

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "third_party/zlib/zlib"]
 	path = third_party/zlib/zlib
 	url = https://chromium.googlesource.com/chromium/src/third_party/zlib
+[submodule "third_party/lss/lss"]
+	path = third_party/lss/lss
+	url = https://chromium.googlesource.com/linux-syscall-support

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,46 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.10)
 project(crashpad LANGUAGES C CXX)
+
+set(CRASHPAD_MAIN_PROJECT OFF)
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    set(CRASHPAD_MAIN_PROJECT ON)
+endif()
+
+option(CRASHPAD_ENABLE_INSTALL "Enable crashpad installation" "${CRASHPAD_MAIN_PROJECT}")
+option(CRASHPAD_ENABLE_INSTALL_DEV "Enable crashpad development installation" "${CRASHPAD_MAIN_PROJECT}")
+
+if(MSVC)
+    set(CRASHPAD_ZLIB_SYSTEM_DEFAULT OFF)
+else()
+    set(CRASHPAD_ZLIB_SYSTEM_DEFAULT ON)
+endif()
+option(CRASHPAD_ZLIB_SYSTEM "Use system zlib library" "${CRASHPAD_ZLIB_SYSTEM_DEFAULT}")
+
+if(CRASHPAD_ZLIB_SYSTEM)
+    find_package(ZLIB REQUIRED)
+endif()
+
+include(GNUInstallDirs)
+set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/crashpad")
+
+function(crashpad_install_target)
+    if(CRASHPAD_ENABLE_INSTALL)
+        install(TARGETS ${ARGN} EXPORT crashpad_export
+            ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+            LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+            RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+        )
+    endif()
+endfunction()
+function(crashpad_install_dev)
+    if(CRASHPAD_ENABLE_INSTALL_DEV)
+        install(${ARGN})
+    endif()
+endfunction()
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(LINUX TRUE)
+endif()
 
 if(WIN32)
     enable_language(ASM_MASM)
@@ -9,7 +50,7 @@ if(WIN32)
             SET(CMAKE_ASM_MASM_COMPILER "uasm")
             SET(CMAKE_ASM_MASM_FLAGS "-win64 -10")
         else()
-            message(FATAL_ERROR "UASM is required for MinGW builds ! Make sure you have it installed")
+            message(FATAL_ERROR "UASM is required for MinGW builds! Make sure you have it installed")
         endif()
     endif()
 else()
@@ -17,78 +58,65 @@ else()
 endif()
 
 set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(LINUX TRUE)
-endif()
-
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/third_party/mini_chromium/mini_chromium")
-
-# These should really be in `compat`, but we want them for the whole project
-if(APPLE)
-    include_directories(SYSTEM "compat/mac")
-else()
-    include_directories(PUBLIC "compat/non_mac")
-endif()
-
-if(LINUX OR ANDROID)
-    include_directories(SYSTEM "compat/linux")
-endif()
-if(ANDROID)
-    include_directories(SYSTEM "compat/android")
-endif()
+add_library(crashpad_interface INTERFACE)
+target_include_directories(crashpad_interface INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/third_party/mini_chromium/mini_chromium>
+)
+target_compile_definitions(crashpad_interface INTERFACE
+    CRASHPAD_LSS_SOURCE_EMBEDDED
+)
 
 if(MSVC)
-    include_directories(SYSTEM "compat/win")
-elseif(MINGW)
-    include_directories(PUBLIC "compat/mingw")
-else()
-    include_directories(PUBLIC "compat/non_win")
-endif()
-
-if(NOT LINUX AND NOT ANDROID)
-    include_directories(SYSTEM "compat/non_elf")
-endif()
-
-if(MSVC)
-    add_definitions(
-        /DNOMINMAX
-        /DUNICODE
-        /DWIN32_LEAN_AND_MEAN
-        /D_CRT_SECURE_NO_WARNINGS
-        /D_HAS_EXCEPTIONS=0
-        /D_UNICODE
-        /FS
-        /W4
-        /WX
-        /Zi
-        /bigobj # Support larger number of sections in obj file.
-        /wd4100 # Unreferenced formal parameter.
-        /wd4127 # Conditional expression is constant.
-        /wd4324 # Structure was padded due to alignment specifier.
-        /wd4351 # New behavior: elements of array will be default initialized.
-        /wd4577 # 'noexcept' used with no exception handling mode specified.
-        /wd4996 # 'X' was declared deprecated.
+    target_compile_definitions(crashpad_interface INTERFACE
+        NOMINMAX
+        UNICODE
+        WIN32_LEAN_AND_MEAN
+        _CRT_SECURE_NO_WARNINGS
+        _HAS_EXCEPTIONS=0
+        _UNICODE
+    )
+    target_compile_options(crashpad_interface INTERFACE
+        $<$<COMPILE_LANGUAGE:C,CXX>:/FS>
+        $<$<COMPILE_LANGUAGE:C,CXX>:/W4>
+        $<$<COMPILE_LANGUAGE:C,CXX>:/WX>
+        $<$<COMPILE_LANGUAGE:C,CXX>:/Zi>
+        $<$<COMPILE_LANGUAGE:C,CXX>:/bigobj> # Support larger number of sections in obj file.
+        $<$<COMPILE_LANGUAGE:C,CXX>:/wd4100> # Unreferenced formal parameter.
+        $<$<COMPILE_LANGUAGE:C,CXX>:/wd4127> # Conditional expression is constant.
+        $<$<COMPILE_LANGUAGE:C,CXX>:/wd4324> # Structure was padded due to alignment specifier.
+        $<$<COMPILE_LANGUAGE:C,CXX>:/wd4351> # New behavior: elements of array will be default initialized.
+        $<$<COMPILE_LANGUAGE:C,CXX>:/wd4577> # 'noexcept' used with no exception handling mode specified.
+        $<$<COMPILE_LANGUAGE:C,CXX>:/wd4996> # 'X' was declared deprecated.
     )
 elseif(MINGW)
-    #redirect to wmain
-    add_link_options(
-        -municode
-    )
+    # redirect to wmain
+    # FIXME: cmake 3.13 added target_link_options
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -municode")
 endif()
+add_library(crashpad::interface ALIAS crashpad_interface)
 
-add_subdirectory(client)
 add_subdirectory(compat)
-add_subdirectory(handler)
 add_subdirectory(minidump)
 add_subdirectory(snapshot)
-add_subdirectory(tools)
 add_subdirectory(util)
 add_subdirectory(third_party/mini_chromium)
+add_subdirectory(client)
 
-if(MSVC)
-    add_subdirectory(third_party/getopt)
-    add_subdirectory(third_party/zlib)
+add_subdirectory(third_party/zlib)
+add_subdirectory(third_party/getopt)
+
+add_subdirectory(tools)
+add_subdirectory(handler)
+
+if(CRASHPAD_ENABLE_INSTALL_DEV)
+    install(EXPORT crashpad_export NAMESPACE crashpad:: FILE crashpad-targets.cmake
+        DESTINATION "${CMAKE_INSTALL_CMAKEDIR}")
+    include(CMakePackageConfigHelpers)
+    configure_package_config_file(crashpad-config.cmake.in crashpad-config.cmake
+        INSTALL_DESTINATION "${CMAKE_INSTALL_CMAKEDIR}"
+    )
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/crashpad-config.cmake" DESTINATION "${CMAKE_INSTALL_CMAKEDIR}")
 endif()

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,4 +1,4 @@
-list(APPEND CLIENT_SOURCES
+add_library(crashpad_client STATIC
     annotation.cc
     annotation.h
     annotation_list.cc
@@ -18,7 +18,7 @@ list(APPEND CLIENT_SOURCES
 )
 
 if(APPLE)
-    list(APPEND CLIENT_SOURCES
+    target_sources(crashpad_client PRIVATE
         crash_report_database_mac.mm
         crashpad_client_mac.cc
         simulate_crash_mac.cc
@@ -27,37 +27,47 @@ if(APPLE)
 endif()
 
 if(LINUX OR ANDROID)
-    list(APPEND CLIENT_SOURCES
-      crashpad_client_linux.cc
-      simulate_crash_linux.h
-      client_argv_handling.cc
-      client_argv_handling.h
-      crashpad_info_note.S
-      crash_report_database_generic.cc
+    target_sources(crashpad_client PRIVATE
+        crashpad_client_linux.cc
+        simulate_crash_linux.h
+        client_argv_handling.cc
+        client_argv_handling.h
+        crashpad_info_note.S
+        crash_report_database_generic.cc
     )
 endif()
 
 if(WIN32)
-    list(APPEND CLIENT_SOURCES
-      crash_report_database_win.cc
-      crashpad_client_win.cc
-      simulate_crash_win.h
+    target_sources(crashpad_client PRIVATE
+        crash_report_database_win.cc
+        crashpad_client_win.cc
+        simulate_crash_win.h
     )
 endif()
 
-add_library(crashpad_client STATIC ${CLIENT_SOURCES})
-target_link_libraries(crashpad_client
-    crashpad_compat
-    crashpad_util
-    mini_chromium
+target_include_directories(crashpad_client INTERFACE
+    "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>"
+    "$<INSTALL_INTERFACE:include/crashpad/client>"
 )
+target_link_libraries(crashpad_client
+    PRIVATE
+        $<BUILD_INTERFACE:crashpad_interface>
+    PUBLIC
+        crashpad_compat
+        crashpad_util
+        mini_chromium
+)
+target_compile_features(crashpad_client PUBLIC cxx_std_14)
+
+set_property(TARGET crashpad_client PROPERTY EXPORT_NAME client)
+add_library(crashpad::client ALIAS crashpad_client)
 
 if(WIN32)
-    target_link_libraries(crashpad_client "rpcrt4")
+    target_link_libraries(crashpad_client PRIVATE rpcrt4)
     if(MSVC)
-        target_compile_options(crashpad_client PUBLIC "/wd4201")
+        target_compile_options(crashpad_client PRIVATE "/wd4201")
     elseif(MINGW)
-        target_compile_options(crashpad_client PRIVATE 
+        target_compile_options(crashpad_client PUBLIC
             "-municode"
         )
     endif()
@@ -73,3 +83,9 @@ if(WIN32)
         )
     endif()
 endif()
+
+crashpad_install_target(crashpad_client)
+crashpad_install_dev(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad/client"
+    FILES_MATCHING PATTERN "*.h"
+)

--- a/compat/CMakeLists.txt
+++ b/compat/CMakeLists.txt
@@ -1,4 +1,4 @@
-list(APPEND COMPAT_SOURCES "")
+set(COMPAT_SOURCES)
 
 if(APPLE)
     list(APPEND COMPAT_SOURCES
@@ -83,13 +83,39 @@ endif()
 
 if(APPLE)
     add_library(crashpad_compat INTERFACE)
-    list(TRANSFORM COMPAT_SOURCES PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")
-    target_sources(crashpad_compat INTERFACE ${COMPAT_SOURCES})
+    set(TI_TYPE "INTERFACE")
 else()
     add_library(crashpad_compat STATIC ${COMPAT_SOURCES})
     set_target_properties(crashpad_compat PROPERTIES LINKER_LANGUAGE CXX)
+    set(TI_TYPE "PUBLIC")
+    target_link_libraries(crashpad_compat PRIVATE
+        $<BUILD_INTERFACE:crashpad_interface>
+    )
 endif()
 
 if(MSVC)
-    target_link_libraries(crashpad_compat getopt)
+    target_include_directories(crashpad_compat ${TI_TYPE} "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/win>")
+elseif(MINGW)
+    target_include_directories(crashpad_compat ${TI_TYPE} "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/mingw>")
+else()
+    target_include_directories(crashpad_compat ${TI_TYPE} "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/non_win>")
 endif()
+
+if(APPLE)
+    target_include_directories(crashpad_compat ${TI_TYPE} "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/mac>")
+else()
+    target_include_directories(crashpad_compat ${TI_TYPE} "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/non_mac>")
+endif()
+
+if(LINUX OR ANDROID)
+    target_include_directories(crashpad_compat ${TI_YPE} "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/linux>")
+endif()
+
+if(ANDROID)
+    target_include_directories(crashpad_compat ${TI_YPE} "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/android>")
+endif()
+
+set_property(TARGET crashpad_compat PROPERTY EXPORT_NAME compat)
+add_library(crashpad::compat ALIAS crashpad_compat)
+
+crashpad_install_target(crashpad_compat)

--- a/crashpad-config.cmake.in
+++ b/crashpad-config.cmake.in
@@ -1,0 +1,10 @@
+include("${CMAKE_CURRENT_LIST_DIR}/crashpad-targets.cmake")
+
+if(@CRASHPAD_ZLIB_SYSTEM@)
+    find_package(ZLIB REQUIRED)
+    target_include_directories(crashpad::zlib INTERFACE ${ZLIB_INCLUDE_DIRS})
+    target_compile_definitions(crashpad::zlib INTERFACE ${ZLIB_COMPILE_DEFINITIONS})
+    target_link_libraries(crashpad::zlib INTERFACE ${ZLIB_LIBRARIES})
+endif()
+
+@PACKAGE_INIT@

--- a/handler/CMakeLists.txt
+++ b/handler/CMakeLists.txt
@@ -1,4 +1,4 @@
-list(APPEND HANDLER_SOURCES
+add_executable(crashpad_handler WIN32
     main.cc
     crash_report_upload_thread.cc
     crash_report_upload_thread.h
@@ -13,7 +13,7 @@ list(APPEND HANDLER_SOURCES
 )
 
 if(APPLE)
-    list(APPEND HANDLER_SOURCES
+    target_sources(crashpad_handler PRIVATE
         mac/crash_report_exception_handler.cc
         mac/crash_report_exception_handler.h
         mac/exception_handler_server.cc
@@ -24,7 +24,7 @@ if(APPLE)
 endif()
 
 if(LINUX OR ANDROID)
-    list(APPEND HANDLER_SOURCES
+    target_sources(crashpad_handler PRIVATE
         linux/capture_snapshot.cc
         linux/capture_snapshot.h
         linux/crash_report_exception_handler.cc
@@ -35,36 +35,35 @@ if(LINUX OR ANDROID)
 endif()
 
 if(LINUX)
-    list(APPEND HANDLER_SOURCES
+    target_sources(crashpad_handler PRIVATE
         linux/cros_crash_report_exception_handler.cc
         linux/cros_crash_report_exception_handler.h
     )
 endif()
 
 if(WIN32)
-    list(APPEND HANDLER_SOURCES
+    target_sources(crashpad_handler PRIVATE
         win/crash_report_exception_handler.cc
         win/crash_report_exception_handler.h
     )
 endif()
 
-if(WIN32)
-    add_executable(crashpad_handler WIN32 ${HANDLER_SOURCES})
-else()
-    add_executable(crashpad_handler ${HANDLER_SOURCES})
-endif()
 target_link_libraries(crashpad_handler
-    crashpad_client
-    crashpad_minidump
-    crashpad_snapshot
-    crashpad_tools
-    crashpad_util
-    mini_chromium
+    PRIVATE
+        $<BUILD_INTERFACE:crashpad_interface>
+    PUBLIC
+        crashpad_client
+        crashpad_getopt
+        crashpad_minidump
+        crashpad_snapshot
+        crashpad_tools
+        crashpad_util
+        mini_chromium
 )
 
 if(WIN32) 
     if(MSVC)
-        target_compile_options(crashpad_handler PUBLIC "/wd4201")
+        target_compile_options(crashpad_handler PRIVATE "/wd4201")
     endif()
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         target_compile_options(crashpad_handler PRIVATE 
@@ -73,3 +72,9 @@ if(WIN32)
     endif()
 endif()
 
+set_property(TARGET crashpad_handler PROPERTY EXPORT_NAME handler)
+add_executable(crashpad::handler ALIAS crashpad_handler)
+
+install(TARGETS crashpad_handler EXPORT crashpad_export
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+)

--- a/minidump/CMakeLists.txt
+++ b/minidump/CMakeLists.txt
@@ -1,4 +1,4 @@
-list(APPEND MINIDUMP_SOURCES
+add_library(crashpad_minidump STATIC
     minidump_annotation_writer.cc
     minidump_annotation_writer.h
     minidump_byte_array_writer.cc
@@ -52,16 +52,18 @@ list(APPEND MINIDUMP_SOURCES
     minidump_writer_util.h
 )
 
-add_library(crashpad_minidump STATIC ${MINIDUMP_SOURCES})
 target_link_libraries(crashpad_minidump
-    crashpad_compat
-    crashpad_snapshot
-    crashpad_util
-    mini_chromium
+    PRIVATE
+        $<BUILD_INTERFACE:crashpad_interface>
+    PUBLIC
+        crashpad_compat
+        crashpad_snapshot
+        crashpad_util
+        mini_chromium
 )
 
 if(MSVC)
-    target_compile_options(crashpad_minidump PUBLIC "/wd4201" "/wd4324")
+    target_compile_options(crashpad_minidump PRIVATE "/wd4201" "/wd4324")
 endif()
 
 if(WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -69,3 +71,8 @@ if(WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         "-Wno-multichar"
     )
 endif()
+
+set_property(TARGET crashpad_minidump PROPERTY EXPORT_NAME minidump)
+add_library(crashpad::minidump ALIAS crashpad_minidump)
+
+crashpad_install_target(crashpad_minidump)

--- a/snapshot/CMakeLists.txt
+++ b/snapshot/CMakeLists.txt
@@ -1,4 +1,4 @@
-list(APPEND SNAPSHOT_SOURCES
+add_library(crashpad_snapshot STATIC
     annotation_snapshot.cc
     annotation_snapshot.h
     capture_memory.cc
@@ -48,7 +48,7 @@ list(APPEND SNAPSHOT_SOURCES
 
 
 if(APPLE)
-    list(APPEND SNAPSHOT_SOURCES
+    target_sources(crashpad_snapshot PRIVATE
         posix/timezone.cc
         posix/timezone.h
         mac/cpu_context_mac.cc
@@ -81,14 +81,14 @@ if(APPLE)
         mac/thread_snapshot_mac.h
     )
 else()
-    list(APPEND SNAPSHOT_SOURCES
+    target_sources(crashpad_snapshot PRIVATE
         crashpad_types/crashpad_info_reader.cc
         crashpad_types/crashpad_info_reader.h
     )
 endif()
 
 if(LINUX OR ANDROID)
-    list(APPEND SNAPSHOT_SOURCES
+    target_sources(crashpad_snapshot PRIVATE
         posix/timezone.cc
         posix/timezone.h
         linux/cpu_context_linux.cc
@@ -130,7 +130,7 @@ if(LINUX OR ANDROID)
 endif()
 
 if(WIN32)
-    list(APPEND SNAPSHOT_SOURCES
+    target_sources(crashpad_snapshot PRIVATE
         win/capture_memory_delegate_win.cc
         win/capture_memory_delegate_win.h
         win/cpu_context_win.cc
@@ -160,25 +160,30 @@ if(WIN32)
     )
 endif()
 
-# TODO: if(x86)
-    list(APPEND SNAPSHOT_SOURCES
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(x86)|(i[3-7]86)")
+    target_sources(crashpad_snapshot PRIVATE
         x86/cpuid_reader.cc
         x86/cpuid_reader.h
     )
-#endif()
+endif()
 
-add_library(crashpad_snapshot STATIC ${SNAPSHOT_SOURCES})
+target_include_directories(crashpad_snapshot INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+)
 target_link_libraries(crashpad_snapshot
-    crashpad_client
-    crashpad_compat
-    crashpad_util
-    mini_chromium
+    PRIVATE
+        $<BUILD_INTERFACE:crashpad_interface>
+    PUBLIC
+        crashpad_client
+        crashpad_compat
+        crashpad_util
+        mini_chromium
 )
 
 if(WIN32)
-    target_link_libraries(crashpad_snapshot "powrprof")
+    target_link_libraries(crashpad_snapshot PRIVATE powrprof)
     if(MSVC)
-        target_compile_options(crashpad_snapshot PUBLIC "/wd4201")
+        target_compile_options(crashpad_snapshot PRIVATE "/wd4201")
     endif()
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         target_compile_options(crashpad_snapshot PRIVATE 
@@ -191,3 +196,8 @@ if(WIN32)
     )
     endif()
 endif()
+
+set_property(TARGET crashpad_snapshot PROPERTY EXPORT_NAME snapshot)
+add_library(crashpad::snapshot ALIAS crashpad_snapshot)
+
+crashpad_install_target(crashpad_snapshot)

--- a/third_party/getopt/CMakeLists.txt
+++ b/third_party/getopt/CMakeLists.txt
@@ -1,6 +1,17 @@
-list(APPEND GETOPT_SOURCES
-    getopt.cc
-    getopt.h
-)
+if(MSVC)
+    add_library(crashpad_getopt STATIC
+        getopt.cc
+        getopt.h
+    )
+    target_include_directories(crashpad_getopt PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    )
+    target_link_libraries(crashpad_getopt PRIVATE
+        $<BUILD_INTERFACE:crashpad_interface>
+    )
+else()
+    add_library(crashpad_getopt INTERFACE)
+endif()
 
-add_library(getopt STATIC ${GETOPT_SOURCES})
+set_property(TARGET crashpad_getopt PROPERTY EXPORT_NAME getopt)
+add_library(crashpad::getopt ALIAS crashpad_getopt)

--- a/third_party/mini_chromium/CMakeLists.txt
+++ b/third_party/mini_chromium/CMakeLists.txt
@@ -1,4 +1,10 @@
-list(APPEND MINI_CHROMIUM_SOURCES
+add_library(mini_chromium STATIC)
+function(mc_append_sources)
+    list(TRANSFORM ARGN PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/mini_chromium/base/")
+    target_sources(mini_chromium PRIVATE ${ARGN})
+endfunction()
+
+mc_append_sources(
     ../build/build_config.h
     atomicops.h
     atomicops_internals_atomicword_compat.h
@@ -66,17 +72,17 @@ list(APPEND MINI_CHROMIUM_SOURCES
 )
 
 if(NOT MINGW)
-    list(APPEND MINI_CHROMIUM_SOURCES
+    mc_append_sources(
         strings/utf_string_conversion_utils.cc
     )
 else()
-    list(APPEND MINI_CHROMIUM_SOURCES
-        ../../utf_string_conversion_utils.mingw.cc
+    mc_append_sources(
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../utf_string_conversion_utils.mingw.cc
     )
 endif()
 
 if(APPLE)
-    list(APPEND MINI_CHROMIUM_SOURCES
+    mc_append_sources(
         mac/close_nocancel.cc
         mac/foundation_util.h
         mac/foundation_util.mm
@@ -98,7 +104,7 @@ if(APPLE)
 endif()
 
 if(WIN32)
-    list(APPEND MINI_CHROMIUM_SOURCES
+    mc_append_sources(
         process/process_metrics_win.cc
         strings/string_util_win.cc
         strings/string_util_win.h
@@ -106,7 +112,7 @@ if(WIN32)
         threading/thread_local_storage_win.cc
     )
 else()
-    list(APPEND MINI_CHROMIUM_SOURCES
+    mc_append_sources(
         files/file_util_posix.cc
         posix/eintr_wrapper.h
         posix/safe_strerror.cc
@@ -119,23 +125,29 @@ else()
     )
 endif()
 
-list(TRANSFORM MINI_CHROMIUM_SOURCES PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/mini_chromium/base/")
-
-add_library(mini_chromium STATIC ${MINI_CHROMIUM_SOURCES})
-
 if(APPLE)
-    target_link_libraries(mini_chromium PUBLIC "-framework ApplicationServices")
-    target_link_libraries(mini_chromium PUBLIC "-framework CoreFoundation")
-    target_link_libraries(mini_chromium PUBLIC "-framework Foundation")
-    target_link_libraries(mini_chromium PUBLIC "-framework IOKit")
-    target_link_libraries(mini_chromium PUBLIC "-framework Security")
+    target_link_libraries(mini_chromium PUBLIC
+        "-framework ApplicationServices"
+        "-framework CoreFoundation"
+        "-framework Foundation"
+        "-framework IOKit"
+        "-framework Security"
+    )
 endif()
+target_include_directories(mini_chromium PUBLIC
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/mini_chromium>"
+    $<INSTALL_INTERFACE:include/crashpad/mini_chromium>
+)
+target_link_libraries(mini_chromium
+    PRIVATE
+        $<BUILD_INTERFACE:crashpad_interface>
+)
 
 if(WIN32)
-    target_link_libraries(mini_chromium "advapi32" "kernel32")
+    target_link_libraries(mini_chromium PRIVATE advapi32 kernel32)
     if(MSVC)
-        target_compile_options(mini_chromium PUBLIC "/wd4201" "/wd4996")
-        target_compile_definitions(mini_chromium PUBLIC
+        target_compile_options(mini_chromium PRIVATE "/wd4201" "/wd4996")
+        target_compile_definitions(mini_chromium PRIVATE
             NOMINMAX
             UNICODE
             WIN32_LEAN_AND_MEAN
@@ -151,3 +163,11 @@ if(WIN32)
         )
     endif()
 endif()
+
+add_library(crashpad::mini_chromium ALIAS mini_chromium)
+
+crashpad_install_target(mini_chromium)
+crashpad_install_dev(DIRECTORY mini_chromium
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad"
+    FILES_MATCHING PATTERN "*.h"
+)

--- a/third_party/zlib/CMakeLists.txt
+++ b/third_party/zlib/CMakeLists.txt
@@ -1,54 +1,83 @@
-list(APPEND ZLIB_SOURCES
-    zlib/adler32.c
-    zlib/compress.c
-    zlib/crc32.c
-    zlib/crc32.h
-    zlib/deflate.c
-    zlib/deflate.h
-    zlib/gzclose.c
-    zlib/gzguts.h
-    zlib/gzlib.c
-    zlib/gzread.c
-    zlib/gzwrite.c
-    zlib/infback.c
-    zlib/inffast.c
-    zlib/inffast.h
-    zlib/inffixed.h
-    zlib/inflate.c
-    zlib/inflate.h
-    zlib/inftrees.c
-    zlib/inftrees.h
-    zlib/names.h
-    zlib/trees.c
-    zlib/trees.h
-    zlib/uncompr.c
-    zlib/zconf.h
-    zlib/zlib.h
-    zlib/zutil.c
-    zlib/zutil.h
-    zlib_crashpad.h
-)
-
-# TODO: x86/x64
-list(APPEND ZLIB_SOURCES
-    zlib/crc_folding.c
-    zlib/fill_window_sse.c
-    zlib/x86.c
-    zlib/x86.h
-)
-
-add_library(zlib STATIC ${ZLIB_SOURCES})
-target_compile_definitions(zlib PUBLIC HAVE_STDARG_H)
-
-include_directories(zlib)
-
-if(MSVC)
-    target_compile_options(zlib PUBLIC
-        "/wd4131" # uses old-style declarator
-        "/wd4244" # conversion from 't1' to 't2', possible loss of data
-        "/wd4245" # conversion from 't1' to 't2', signed/unsigned mismatch
-        "/wd4267" # conversion from 'size_t' to 't', possible loss of data
-        "/wd4324" # structure was padded due to alignment specifier
-        "/wd4702" # unreachable code
+if(CRASHPAD_ZLIB_SYSTEM)
+    add_library(crashpad_zlib INTERFACE)
+    string(REPLACE ";" "$<SEMICOLON>" GENEX_ZLIB_LIBRARIES "${ZLIB_LIBRARIES}")
+    target_include_directories(crashpad_zlib INTERFACE
+        $<BUILD_INTERFACE:${ZLIB_INCLUDE_DIRS}>
     )
+    target_compile_definitions(crashpad_zlib INTERFACE
+        ZLIB_CONST
+        CRASHPAD_ZLIB_SOURCE_SYSTEM
+        $<BUILD_INTERFACE:${ZLIB_COMPILE_DEFINITIONS}>
+    )
+    target_link_libraries(crashpad_zlib INTERFACE $<BUILD_INTERFACE:${GENEX_ZLIB_LIBRARIES}>)
+else()
+    add_library(crashpad_zlib STATIC
+        zlib/adler32.c
+        zlib/compress.c
+        zlib/crc32.c
+        zlib/crc32.h
+        zlib/deflate.c
+        zlib/deflate.h
+        zlib/gzclose.c
+        zlib/gzguts.h
+        zlib/gzlib.c
+        zlib/gzread.c
+        zlib/gzwrite.c
+        zlib/infback.c
+        zlib/inffast.c
+        zlib/inffast.h
+        zlib/inffixed.h
+        zlib/inflate.c
+        zlib/inflate.h
+        zlib/inftrees.c
+        zlib/inftrees.h
+        zlib/names.h
+        zlib/trees.c
+        zlib/trees.h
+        zlib/uncompr.c
+        zlib/zconf.h
+        zlib/zlib.h
+        zlib/zutil.c
+        zlib/zutil.h
+        zlib_crashpad.h
+    )
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(x86)|(i[3-7]86)|(AMD64)")
+        target_sources(crashpad_zlib PRIVATE
+            zlib/crc_folding.c
+            zlib/fill_window_sse.c
+            zlib/x86.c
+            zlib/x86.h
+        )
+    endif()
+    target_compile_definitions(crashpad_zlib PUBLIC
+        CRASHPAD_ZLIB_SOURCE_EMBEDDED
+    )
+    target_compile_definitions(crashpad_zlib
+        PUBLIC
+            ZLIB_CONST
+        PRIVATE
+            HAVE_STDARG_H
+    )
+    target_include_directories(crashpad_zlib PRIVATE
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/zlib>"
+    )
+    target_link_libraries(crashpad_zlib PRIVATE
+        $<BUILD_INTERFACE:crashpad_interface>
+    )
+
+    if(MSVC)
+        target_compile_options(crashpad_zlib PRIVATE
+            "/wd4131" # uses old-style declarator
+            "/wd4244" # conversion from 't1' to 't2', possible loss of data
+            "/wd4245" # conversion from 't1' to 't2', signed/unsigned mismatch
+            "/wd4267" # conversion from 'size_t' to 't', possible loss of data
+            "/wd4324" # structure was padded due to alignment specifier
+            "/wd4702" # unreachable code
+        )
+    endif()
 endif()
+
+set_property(TARGET crashpad_zlib PROPERTY EXPORT_NAME zlib)
+add_library(crashpad::zlib ALIAS crashpad_zlib)
+
+crashpad_install_target(crashpad_zlib)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,11 +1,105 @@
-list(APPEND TOOLS_SOURCES
+add_library(crashpad_tools STATIC
     tool_support.cc
     tool_support.h
 )
-
-add_library(crashpad_tools STATIC ${TOOLS_SOURCES})
-target_link_libraries(crashpad_tools
-    mini_chromium
+target_link_libraries(crashpad_tools PRIVATE
+    $<BUILD_INTERFACE:crashpad_interface>
 )
 
-# TODO: do we need any tool executables?
+set_property(TARGET crashpad_tools PROPERTY EXPORT_NAME tools)
+add_library(crashpad::tools ALIAS crashpad_tools)
+
+crashpad_install_target(crashpad_tools)
+
+if(CRASHPAD_BUILD_TOOLS)
+    add_executable(crashpad_database_util
+        crashpad_database_util.cc
+    )
+    target_link_libraries(crashpad_database_util PRIVATE
+        crashpad_client
+        crashpad_compat
+        crashpad_getopt
+        crashpad_tools
+    )
+    crashpad_install_target(crashpad_database_util)
+
+    add_executable(crashpad_http_upload
+        crashpad_http_upload.cc
+    )
+    target_link_libraries(crashpad_http_upload PRIVATE
+        crashpad_client
+        crashpad_compat
+        crashpad_getopt
+        crashpad_tools
+        crashpad_zlib
+        mini_chromium
+    )
+    crashpad_install_target(crashpad_http_upload)
+
+    add_executable(crashpad_generate_dump
+        generate_dump.cc
+    )
+    target_link_libraries(crashpad_generate_dump PRIVATE
+        crashpad_getopt
+        crashpad_minidump
+        crashpad_snapshot
+        crashpad_tools
+        mini_chromium
+    )
+    if(APPLE)
+        # FIXME: cmake 3.13 added target_link_options
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -sectcreate __TEXT __info_plist \"${CMAKE_CURRENT_SOURCE_DIR}/mac/sectaskaccess_info.plist\"")
+    endif()
+    crashpad_install_target(crashpad_generate_dump)
+
+    if(APPLE)
+        add_executable(run_with_crashpad
+            run_with_crashpad.cc
+        )
+        target_link_libraries(run_with_crashpad PRIVATE
+            crashpad_client
+            crashpad_compat
+            crashpad_tools
+            crashpad_util
+            mini_chromium
+        )
+        crashpad_install_target(run_with_crashpad)
+
+        add_executable(catch_exception_tool
+            mac/catch_exception_tool.cc
+        )
+        target_link_libraries(catch_exception_tool PRIVATE
+            crashpad_compat
+            crashpad_tools
+            crashpad_util
+            mini_chromium
+        )
+        crashpad_install_target(catch_exception_tool)
+
+        add_executable(exception_port_tool
+            mac/exception_port_tool.cc
+        )
+        target_link_libraries(exception_port_tool PRIVATE
+            crashpad_compat
+            crashpad_tools
+            crashpad_util
+            mini_chromium
+        )
+        # FIXME: cmake 3.13 added target_link_options
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -sectcreate __TEXT __info_plist \"${CMAKE_CURRENT_SOURCE_DIR}/mac/sectaskaccess_info.plist\"")
+        crashpad_install_target(exception_port_tool)
+
+        add_executable(on_demand_service_tool
+            mac/on_demand_service_tool.mm
+        )
+        target_link_libraries(on_demand_service_tool PRIVATE
+            -framework CoreFoundation
+            -framework Foundation
+            crashpad_compat
+            crashpad_tools
+            crashpad_util
+            mini_chromium
+        )
+        crashpad_install_target(on_demand_service_tool)
+    endif()
+endif()

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,4 +1,4 @@
-list(APPEND UTIL_SOURCES
+add_library(crashpad_util STATIC
     file/delimited_file_reader.cc
     file/delimited_file_reader.h
     file/directory_reader.h
@@ -102,7 +102,7 @@ list(APPEND UTIL_SOURCES
 )
 
 if(NOT WIN32)
-    list(APPEND UTIL_SOURCES
+    target_sources(crashpad_util PRIVATE
         file/directory_reader_posix.cc
         file/file_io_posix.cc
         file/filesystem_posix.cc
@@ -130,7 +130,7 @@ if(NOT WIN32)
 endif()
 
 if(APPLE)
-    list(APPEND UTIL_SOURCES
+    target_sources(crashpad_util PRIVATE
         mac/checked_mach_address_range.h
         mac/launchd.h
         mac/launchd.mm
@@ -183,7 +183,7 @@ if(APPLE)
 endif()
 
 if(LINUX OR ANDROID)
-    list(APPEND UTIL_SOURCES
+    target_sources(crashpad_util PRIVATE
         net/http_transport_socket.cc
         linux/address_types.h
         linux/auxiliary_vector.cc
@@ -231,7 +231,7 @@ if(LINUX OR ANDROID)
 endif()
 
 if(WIN32)
-    list(APPEND UTIL_SOURCES
+    target_sources(crashpad_util PRIVATE
         file/directory_reader_win.cc
         file/file_io_win.cc
         file/filesystem_win.cc
@@ -291,73 +291,71 @@ endif()
 
 # Copied from: https://github.com/qedsoftware/crashpad/blob/3583c50a6575857abcf140f6ea3b8d11390205b3/util/CMakeLists.txt#L196-L233
 if(APPLE)
-  set(def_relative_files "exc.defs" "mach_exc.defs" "notify.defs")
-  set(input_files "")
-  foreach(x ${def_relative_files})
-    # CMAKE_OSX_SYSROOT may be empty (e.g. for Makefile generators),
-    # in this case files will be taken from root.
-    set(full_path "${CMAKE_OSX_SYSROOT}/usr/include/mach/${x}")
-    if(NOT EXISTS "${full_path}")
-      message(FATAL_ERROR "File not found: ${full_path}")
-    endif()
-    list(APPEND input_files "${full_path}")
-  endforeach()
-  list(APPEND input_files "${CMAKE_CURRENT_LIST_DIR}/mach/child_port.defs")
-
-  find_package(PythonInterp 2.7 REQUIRED)
-
-  set(output_dir "${CMAKE_CURRENT_BINARY_DIR}/util/mach")
-  file(MAKE_DIRECTORY "${output_dir}")
-
-  # Create generate rule for each input file. Add each generated output
-  # as a source to the target.
-  foreach(input ${input_files})
-    get_filename_component(name_we "${input}" NAME_WE)
-    set(output_files "")
-    foreach(suffix "User.c" "Server.c" ".h" "Server.h")
-      list(APPEND output_files "${output_dir}/${name_we}${suffix}")
+    set(def_relative_files "exc.defs" "mach_exc.defs" "notify.defs")
+    set(input_files "")
+    foreach(x ${def_relative_files})
+        # CMAKE_OSX_SYSROOT may be empty (e.g. for Makefile generators),
+        # in this case files will be taken from root.
+        set(full_path "${CMAKE_OSX_SYSROOT}/usr/include/mach/${x}")
+        if(NOT EXISTS "${full_path}")
+            message(FATAL_ERROR "File not found: ${full_path}")
+        endif()
+        list(APPEND input_files "${full_path}")
     endforeach()
-    add_custom_command(
-        OUTPUT
-        ${output_files}
-        COMMAND
-        "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mach/mig.py" "${input}" ${output_files}
-        DEPENDS
-        "${CMAKE_CURRENT_SOURCE_DIR}/mach/mig.py" "${input}"
-    )
-    list(APPEND UTIL_SOURCES ${output_files})
-  endforeach()
+    list(APPEND input_files "${CMAKE_CURRENT_LIST_DIR}/mach/child_port.defs")
 
-  include_directories("${CMAKE_CURRENT_BINARY_DIR}")
+    find_package(PythonInterp 2.7 REQUIRED)
+
+    set(output_dir "${CMAKE_CURRENT_BINARY_DIR}/util/mach")
+    file(MAKE_DIRECTORY "${output_dir}")
+
+    # Create generate rule for each input file. Add each generated output
+    # as a source to the target.
+    foreach(input ${input_files})
+        get_filename_component(name_we "${input}" NAME_WE)
+        set(output_files "")
+        foreach(suffix "User.c" "Server.c" ".h" "Server.h")
+            list(APPEND output_files "${output_dir}/${name_we}${suffix}")
+        endforeach()
+        add_custom_command(
+            OUTPUT
+            ${output_files}
+            COMMAND
+            "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mach/mig.py" "${input}" ${output_files}
+            DEPENDS
+            "${CMAKE_CURRENT_SOURCE_DIR}/mach/mig.py" "${input}"
+        )
+        target_sources(crashpad_util PRIVATE ${output_files})
+    endforeach()
+
+    include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 endif()
 
-add_library(crashpad_util STATIC ${UTIL_SOURCES})
-target_link_libraries(crashpad_util PUBLIC
-    crashpad_compat
-    mini_chromium
+target_include_directories(crashpad_util PRIVATE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+)
+target_link_libraries(crashpad_util
+    PRIVATE
+        $<BUILD_INTERFACE:crashpad_interface>
+    PUBLIC
+        crashpad_compat
+        crashpad_zlib
+        mini_chromium
 )
 
-target_compile_definitions(crashpad_util PUBLIC "-DZLIB_CONST")
-
-if(MSVC)
-    target_compile_definitions(crashpad_util PUBLIC "-DCRASHPAD_ZLIB_SOURCE_EMBEDDED")
-    target_link_libraries(crashpad_util PUBLIC zlib)
-else()
-    target_compile_definitions(crashpad_util PUBLIC "-DCRASHPAD_ZLIB_SOURCE_SYSTEM")
-    target_link_libraries(crashpad_util PUBLIC "z")
-endif()
-
 if(APPLE)
-    target_link_libraries(crashpad_util PUBLIC "bsm")
-    target_link_libraries(crashpad_util PUBLIC "-framework CoreFoundation")
-    target_link_libraries(crashpad_util PUBLIC "-framework Foundation")
-    target_link_libraries(crashpad_util PUBLIC "-framework IOKit")
+    target_link_libraries(crashpad_util PRIVATE
+        bsm
+        "-framework CoreFoundation"
+        "-framework Foundation"
+        "-framework IOKit"
+    )
 endif()
 
 if(WIN32)
-    target_link_libraries(crashpad_util PUBLIC "user32" "version" "winhttp")
+    target_link_libraries(crashpad_util PRIVATE user32 version winhttp)
     if(MSVC)
-        target_compile_options(crashpad_util PUBLIC "/wd4201")
+        target_compile_options(crashpad_util PRIVATE "/wd4201")
     elseif(MINGW)
         target_compile_options(crashpad_util PRIVATE 
             $<$<COMPILE_LANGUAGE:CXX>:-municode>
@@ -373,3 +371,8 @@ if(WIN32)
         )
     endif()
 endif()
+
+set_property(TARGET crashpad_util PROPERTY EXPORT_NAME util)
+add_library(crashpad::util ALIAS crashpad_util)
+
+crashpad_install_target(crashpad_util)


### PR DESCRIPTION
This allows sentry-native to use `crashpad` by simply linking to `crashpad::client`.

No adding include directories, no extra defines, no c++ standards.