### PR TITLE
cmake: remove /W3 from CMAKE_C_FLAGS and CMAKE_CXX_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,8 @@ if(MSVC)
         _HAS_EXCEPTIONS=0
         _UNICODE
     )
+    string(REGEX REPLACE "/[Ww][0123]" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+    string(REGEX REPLACE "/[Ww][0123]" "" CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS}")
     target_compile_options(crashpad_interface INTERFACE
         $<$<COMPILE_LANGUAGE:C,CXX>:/FS>
         $<$<COMPILE_LANGUAGE:C,CXX>:/W4>


### PR DESCRIPTION
Remove `/W3` (or similar) from `CMAKE_{C,CXX}_FLAGS`.

This avoids a lot of warnings about `/W3` being overridden with `/W4`.