### PR TITLE
linux: Fix build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 project(crashpad LANGUAGES C CXX)
 
 set(CRASHPAD_MAIN_PROJECT OFF)

--- a/compat/CMakeLists.txt
+++ b/compat/CMakeLists.txt
@@ -93,6 +93,10 @@ else()
     )
 endif()
 
+if(LINUX)
+    target_link_libraries(crashpad_compat PRIVATE dl)
+endif()
+
 if(MSVC)
     target_include_directories(crashpad_compat ${TI_TYPE} "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/win>")
 elseif(MINGW)
@@ -108,11 +112,11 @@ else()
 endif()
 
 if(LINUX OR ANDROID)
-    target_include_directories(crashpad_compat ${TI_YPE} "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/linux>")
+    target_include_directories(crashpad_compat ${TI_TYPE} "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/linux>")
 endif()
 
 if(ANDROID)
-    target_include_directories(crashpad_compat ${TI_YPE} "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/android>")
+    target_include_directories(crashpad_compat ${TI_TYPE} "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/android>")
 endif()
 
 set_property(TARGET crashpad_compat PROPERTY EXPORT_NAME compat)

--- a/third_party/mini_chromium/CMakeLists.txt
+++ b/third_party/mini_chromium/CMakeLists.txt
@@ -135,6 +135,11 @@ if(APPLE)
         "-framework Security"
     )
 endif()
+
+if(LINUX)
+    target_link_libraries(mini_chromium PRIVATE pthread)
+endif()
+
 target_include_directories(mini_chromium PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/mini_chromium>"
     $<INSTALL_INTERFACE:include/crashpad/mini_chromium>

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -239,6 +239,7 @@ if(LINUX OR ANDROID)
         linux/traits.h
         misc/capture_context_linux.S
         misc/paths_linux.cc
+        misc/time_linux.cc
         posix/process_info_linux.cc
         process/process_memory_linux.cc
         process/process_memory_linux.h
@@ -369,6 +370,10 @@ if(APPLE)
         "-framework Foundation"
         "-framework IOKit"
     )
+endif()
+
+if(LINUX)
+    target_link_libraries(crashpad_util PRIVATE pthread)
 endif()
 
 if(WIN32)


### PR DESCRIPTION
The Linux version of Crashpad wasn't building due to a few oversights in the `CMakeLists.txt` files.