### PR TITLE
fix: Add a Host Header to the upload request

### DIFF
--- a/util/net/http_transport_socket.cc
+++ b/util/net/http_transport_socket.cc
@@ -328,11 +328,15 @@ base::ScopedFD CreateSocket(const std::string& hostname,
 
 bool WriteRequest(Stream* stream,
                   const std::string& method,
+                  const std::string& hostname,
                   const std::string& resource,
                   const HTTPHeaders& headers,
                   HTTPBodyStream* body_stream) {
-  std::string request_line = base::StringPrintf(
-      "%s %s HTTP/1.0\r\n", method.c_str(), resource.c_str());
+  std::string request_line =
+      base::StringPrintf("%s %s HTTP/1.0\r\nHost: %s\r\n",
+                         method.c_str(),
+                         resource.c_str(),
+                         hostname.c_str());
   if (!stream->LoggingWrite(request_line.data(), request_line.size()))
     return false;
 
@@ -574,8 +578,12 @@ bool HTTPTransportSocket::ExecuteSynchronously(std::string* response_body) {
   std::unique_ptr<Stream> stream(std::make_unique<FdStream>(sock.get()));
 #endif  // CRASHPAD_USE_BORINGSSL
 
-  if (!WriteRequest(
-          stream.get(), method(), resource, headers(), body_stream())) {
+  if (!WriteRequest(stream.get(),
+                    method(),
+                    hostname,
+                    resource,
+                    headers(),
+                    body_stream())) {
     return false;
   }
 


### PR DESCRIPTION
This fixes https minidump uploads on linux.