### PR TITLE
fix: missing flags for zlib compilation

### DIFF
--- a/third_party/zlib/CMakeLists.txt
+++ b/third_party/zlib/CMakeLists.txt
@@ -48,6 +48,10 @@ else()
             zlib/x86.c
             zlib/x86.h
         )
+
+        if(NOT MSVC)
+            target_compile_options(crashpad_zlib PRIVATE -msse4.2 -mpclmul)
+        endif()
     endif()
     target_compile_definitions(crashpad_zlib PUBLIC
         CRASHPAD_ZLIB_SOURCE_EMBEDDED


### PR DESCRIPTION
See https://github.com/getsentry/sentry-native/issues/354#issuecomment-675329198.

Fixes getsentry/sentry-native#354.
