### PR TITLE
Install 'handler' and 'util' development header files.

### DIFF
--- a/handler/CMakeLists.txt
+++ b/handler/CMakeLists.txt
@@ -74,6 +74,10 @@ set_property(TARGET crashpad_handler_lib PROPERTY EXPORT_NAME handler)
 add_library(crashpad::handler_lib ALIAS crashpad_handler_lib)
 
 crashpad_install_target(crashpad_handler_lib)
+crashpad_install_dev(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad/handler"
+    FILES_MATCHING PATTERN "*.h"
+)
 
 if(NOT IOS)
     add_executable(crashpad_handler WIN32

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -487,3 +487,7 @@ set_property(TARGET crashpad_util PROPERTY EXPORT_NAME util)
 add_library(crashpad::util ALIAS crashpad_util)
 
 crashpad_install_target(crashpad_util)
+crashpad_install_dev(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad/util"
+    FILES_MATCHING PATTERN "*.h"
+)


### PR DESCRIPTION
This patch makes CMake install 'handler' and 'util' library development files in addition to existing 'client' and 'mini_chromium' files.

The 'handler' headers are necessary when compiling own crash handler executables. Some files in 'util' are included from 'client' headers. For example `client/crashpad_client.h` includes `util/file/file_io.h` which is missing.