### PR TITLE
Fix cross-compilation from Intel to Apple Silicon MacOS.

### DIFF
--- a/third_party/zlib/CMakeLists.txt
+++ b/third_party/zlib/CMakeLists.txt
@@ -41,7 +41,13 @@ else()
         zlib/zutil.h
         zlib_crashpad.h
     )
-    if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(x86)|(i[3-7]86)|(AMD64)")
+    if (APPLE)
+        get_property(archs TARGET crashpad_zlib PROPERTY OSX_ARCHITECTURES)
+    endif()
+    if(NOT archs)
+        set(archs ${CMAKE_SYSTEM_PROCESSOR})
+    endif()
+    if(archs MATCHES "(x86_64)|(x86)|(i[3-7]86)|(AMD64)")
         target_sources(crashpad_zlib PRIVATE
             zlib/crc_folding.c
             zlib/fill_window_sse.c
@@ -52,6 +58,8 @@ else()
         if(NOT MSVC)
             target_compile_options(crashpad_zlib PRIVATE -msse4.2 -mpclmul)
         endif()
+    else()
+        target_sources(crashpad_zlib PRIVATE zlib/simd_stub.c)
     endif()
     target_compile_definitions(crashpad_zlib PUBLIC
         CRASHPAD_ZLIB_SOURCE_EMBEDDED


### PR DESCRIPTION
CMake had trouble detecting the target architecture through `CMAKE_SYSTEM_PROCESSOR` on MacOS.
This is similar to https://github.com/getsentry/crashpad/pull/31.

Additionally ARM needs a stub implementation to replace the x86 optimizations, I have taken the implementation from the original build files:
https://github.com/getsentry/crashpad/blob/cb520bd41fdea18a4d842efabeac61a2a5beaa61/third_party/zlib/BUILD.gn#L140-L142

Fixes https://github.com/getsentry/sentry-native/issues/486.

I couldn't test this because of no access to an Apple Silicon machine, but I confirmed that it builds.

