### PR TITLE
fix: CMAKE_ASM_FLAGS with multiple OSX_ARCHITECTURES

### DIFF
--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -429,7 +429,8 @@ if(APPLE)
     get_property(archs TARGET crashpad_util PROPERTY OSX_ARCHITECTURES)
     if (archs)
         list(TRANSFORM archs PREPEND "-arch ")
-        set(CMAKE_ASM_FLAGS "${CFLAGS} ${archs}")
+        list(JOIN archs " " archs_str)
+        set(CMAKE_ASM_FLAGS "${CFLAGS} ${archs_str}")
     endif()
 
     target_link_libraries(crashpad_util PRIVATE


### PR DESCRIPTION
This fixes macOS universal build with `-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64`

Before, the resulting flags would be semicolon separated on the build command line: `-arch arm64;-arch x86_64`, the default behavior of converting a list to a string in CMake.