### PR TITLE
Add missing installed header (build/chromeos_buildflags.h)

### DIFF
--- a/third_party/mini_chromium/CMakeLists.txt
+++ b/third_party/mini_chromium/CMakeLists.txt
@@ -207,3 +207,7 @@ crashpad_install_dev(DIRECTORY mini_chromium
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad"
     FILES_MATCHING PATTERN "*.h"
 )
+crashpad_install_dev(DIRECTORY build
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/crashpad/mini_chromium"
+    FILES_MATCHING PATTERN "*.h"
+)


### PR DESCRIPTION
When using an installed version of this fork of crashpad,
compilation failed because of a missing header (`build/chromeos_buildflags.h`).

Fix this error by installing the missing header to `include/crashpad/mini_chromium/build`.

repro:
```c++
#include "client/crashpad_client.h"
#include "client/settings.h"
int main() {
    return 0;
}
```