### PR TITLE
feat: Write client-side stacktraces to the minidump (NATIVE-197)

### DIFF
--- a/minidump/CMakeLists.txt
+++ b/minidump/CMakeLists.txt
@@ -30,6 +30,8 @@ add_library(crashpad_minidump STATIC
     minidump_rva_list_writer.h
     minidump_simple_string_dictionary_writer.cc
     minidump_simple_string_dictionary_writer.h
+    minidump_stacktrace_writer.cc
+    minidump_stacktrace_writer.h
     minidump_stream_writer.cc
     minidump_stream_writer.h
     minidump_string_writer.cc

--- a/minidump/minidump_extensions.h
+++ b/minidump/minidump_extensions.h
@@ -15,9 +15,9 @@
 #ifndef CRASHPAD_MINIDUMP_MINIDUMP_EXTENSIONS_H_
 #define CRASHPAD_MINIDUMP_MINIDUMP_EXTENSIONS_H_
 
-#include <windows.h>
 #include <dbghelp.h>
 #include <stdint.h>
+#include <windows.h>
 #include <winnt.h>
 
 #include "base/compiler_specific.h"
@@ -32,7 +32,7 @@
 // disable it with other silly warnings in the build files. See:
 //   https://connect.microsoft.com/VisualStudio/feedback/details/1114440
 #pragma warning(push)
-#pragma warning(disable: 4200)
+#pragma warning(disable : 4200)
 
 #define PACKED
 #pragma pack(push, 1)
@@ -105,6 +105,14 @@ enum MinidumpStreamType : uint32_t {
 
   //! \brief The last reserved crashpad stream.
   kMinidumpStreamTypeCrashpadLastReservedStream = 0x4350ffff,
+
+  // 0x5379 = "Sy"
+
+  //! \brief The stream type for client-side stack traces.
+  kMinidumpStreamTypeSentryStackTraces = 0x53790001,
+
+  //! \brief The last reserved Sentry stream.
+  kMinidumpStreamTypeSentryLastReservedStream = 0x5379ffff,
 };
 
 //! \brief A variable-length UTF-8-encoded string carried within a minidump
@@ -439,8 +447,7 @@ struct ALIGNAS(4) PACKED MinidumpCrashpadInfo {
         report_id(),
         client_id(),
         simple_annotations(),
-        module_list() {
-  }
+        module_list() {}
 
   //! \brief The structure’s currently-defined version number.
   //!

--- a/minidump/minidump_extensions.h
+++ b/minidump/minidump_extensions.h
@@ -15,9 +15,9 @@
 #ifndef CRASHPAD_MINIDUMP_MINIDUMP_EXTENSIONS_H_
 #define CRASHPAD_MINIDUMP_MINIDUMP_EXTENSIONS_H_
 
+#include <windows.h>
 #include <dbghelp.h>
 #include <stdint.h>
-#include <windows.h>
 #include <winnt.h>
 
 #include "base/compiler_specific.h"
@@ -32,7 +32,7 @@
 // disable it with other silly warnings in the build files. See:
 //   https://connect.microsoft.com/VisualStudio/feedback/details/1114440
 #pragma warning(push)
-#pragma warning(disable : 4200)
+#pragma warning(disable: 4200)
 
 #define PACKED
 #pragma pack(push, 1)
@@ -447,7 +447,8 @@ struct ALIGNAS(4) PACKED MinidumpCrashpadInfo {
         report_id(),
         client_id(),
         simple_annotations(),
-        module_list() {}
+        module_list() {
+    }
 
   //! \brief The structure’s currently-defined version number.
   //!

--- a/minidump/minidump_file_writer.cc
+++ b/minidump/minidump_file_writer.cc
@@ -24,8 +24,8 @@
 #include "minidump/minidump_memory_writer.h"
 #include "minidump/minidump_misc_info_writer.h"
 #include "minidump/minidump_module_writer.h"
+#include "minidump/minidump_stacktrace_writer.h"
 #include "minidump/minidump_system_info_writer.h"
-#include "minidump/minidump_thread_id_map.h"
 #include "minidump/minidump_thread_writer.h"
 #include "minidump/minidump_unloaded_module_writer.h"
 #include "minidump/minidump_user_extension_stream_data_source.h"
@@ -51,8 +51,7 @@ MinidumpFileWriter::MinidumpFileWriter()
   header_.Flags = MiniDumpNormal;
 }
 
-MinidumpFileWriter::~MinidumpFileWriter() {
-}
+MinidumpFileWriter::~MinidumpFileWriter() {}
 
 void MinidumpFileWriter::InitializeFromSnapshot(
     const ProcessSnapshot* process_snapshot) {
@@ -102,6 +101,12 @@ void MinidumpFileWriter::InitializeFromSnapshot(
   auto module_list = std::make_unique<MinidumpModuleListWriter>();
   module_list->InitializeFromSnapshot(process_snapshot->Modules());
   add_stream_result = AddStream(std::move(module_list));
+  DCHECK(add_stream_result);
+
+  auto stacktrace_list = std::make_unique<MinidumpStacktraceListWriter>();
+  stacktrace_list->InitializeFromSnapshot(process_snapshot->Threads(),
+                                          thread_id_map);
+  add_stream_result = AddStream(std::move(stacktrace_list));
   DCHECK(add_stream_result);
 
   auto unloaded_modules = process_snapshot->UnloadedModules();

--- a/minidump/minidump_file_writer.cc
+++ b/minidump/minidump_file_writer.cc
@@ -26,6 +26,7 @@
 #include "minidump/minidump_module_writer.h"
 #include "minidump/minidump_stacktrace_writer.h"
 #include "minidump/minidump_system_info_writer.h"
+#include "minidump/minidump_thread_id_map.h"
 #include "minidump/minidump_thread_writer.h"
 #include "minidump/minidump_unloaded_module_writer.h"
 #include "minidump/minidump_user_extension_stream_data_source.h"

--- a/minidump/minidump_stacktrace_writer.cc
+++ b/minidump/minidump_stacktrace_writer.cc
@@ -51,8 +51,6 @@ void MinidumpStacktraceListWriter::InitializeFromSnapshot(
     // That would be https://getsentry.atlassian.net/browse/NATIVE-198
     // auto frames = thread_snapshot->StackTrace();
     std::vector<FrameSnapshot> frames;
-    frames.emplace_back(0xfff70001, std::string("uiaeo"));
-    frames.emplace_back(0xfff70002, std::string("snrtdy"));
 
     for (auto frame_snapshot : frames) {
       internal::RawFrame frame;

--- a/minidump/minidump_stacktrace_writer.cc
+++ b/minidump/minidump_stacktrace_writer.cc
@@ -7,14 +7,8 @@
 #include <utility>
 
 #include "base/logging.h"
-#include "base/numerics/safe_conversions.h"
-#include "minidump/minidump_string_writer.h"
-#include "minidump/minidump_writer_util.h"
 #include "snapshot/thread_snapshot.h"
 #include "util/file/file_writer.h"
-#include "util/misc/implicit_cast.h"
-#include "util/numeric/in_range_cast.h"
-#include "util/numeric/safe_assignment.h"
 
 namespace crashpad {
 
@@ -39,7 +33,7 @@ void MinidumpStacktraceListWriter::InitializeFromSnapshot(
   for (auto thread_snapshot : thread_snapshots) {
     internal::RawThread thread;
     thread.thread_id = thread_snapshot->ThreadID();
-    thread.start_frame = frames_.size();
+    thread.start_frame = (uint32_t)frames_.size();
 
     // TODO: Create a stub that will later return a real stack trace:
     // That would be https://getsentry.atlassian.net/browse/NATIVE-198
@@ -51,27 +45,27 @@ void MinidumpStacktraceListWriter::InitializeFromSnapshot(
     for (auto frame_snapshot : frames) {
       internal::RawFrame frame;
       frame.instruction_addr = frame_snapshot.InstructionAddr();
-      frame.symbol_offset = symbol_bytes_.size();
+      frame.symbol_offset = (uint32_t)symbol_bytes_.size();
 
       auto symbol = frame_snapshot.Symbol();
 
       symbol_bytes_.reserve(symbol.size());
       symbol_bytes_.insert(symbol_bytes_.end(), symbol.begin(), symbol.end());
 
-      frame.symbol_len = symbol.size();
+      frame.symbol_len = (uint32_t)symbol.size();
 
       frames_.push_back(frame);
     }
 
-    thread.num_frames = frames_.size() - thread.start_frame;
+    thread.num_frames = (uint32_t)frames_.size() - thread.start_frame;
 
     threads_.push_back(thread);
   }
 
   stacktrace_header_.version = 1;
-  stacktrace_header_.num_threads = threads_.size();
-  stacktrace_header_.num_frames = frames_.size();
-  stacktrace_header_.symbol_bytes = symbol_bytes_.size();
+  stacktrace_header_.num_threads = (uint32_t)threads_.size();
+  stacktrace_header_.num_frames = (uint32_t)frames_.size();
+  stacktrace_header_.symbol_bytes = (uint32_t)symbol_bytes_.size();
 }
 
 size_t MinidumpStacktraceListWriter::SizeOfObject() {

--- a/minidump/minidump_stacktrace_writer.cc
+++ b/minidump/minidump_stacktrace_writer.cc
@@ -1,0 +1,121 @@
+
+#include "minidump/minidump_stacktrace_writer.h"
+
+#include <stddef.h>
+
+#include <limits>
+#include <utility>
+
+#include "base/logging.h"
+#include "base/numerics/safe_conversions.h"
+#include "minidump/minidump_string_writer.h"
+#include "minidump/minidump_writer_util.h"
+#include "snapshot/thread_snapshot.h"
+#include "util/file/file_writer.h"
+#include "util/misc/implicit_cast.h"
+#include "util/numeric/in_range_cast.h"
+#include "util/numeric/safe_assignment.h"
+
+namespace crashpad {
+
+MinidumpStacktraceListWriter::MinidumpStacktraceListWriter()
+    : MinidumpStreamWriter(),
+      threads_(),
+      frames_(),
+      symbol_bytes_(),
+      stacktrace_header_() {}
+
+MinidumpStacktraceListWriter::~MinidumpStacktraceListWriter() {}
+
+void MinidumpStacktraceListWriter::InitializeFromSnapshot(
+    const std::vector<const ThreadSnapshot*>& thread_snapshots,
+    const MinidumpThreadIDMap& thread_id_map) {
+  DCHECK_EQ(state(), kStateMutable);
+
+  DCHECK(threads_.empty());
+  DCHECK(frames_.empty());
+  DCHECK(symbol_bytes_.empty());
+
+  for (auto thread_snapshot : thread_snapshots) {
+    internal::RawThread thread;
+    thread.thread_id = thread_snapshot->ThreadID();
+    thread.start_frame = frames_.size();
+
+    // TODO: Create a stub that will later return a real stack trace:
+    // That would be https://getsentry.atlassian.net/browse/NATIVE-198
+    // auto frames = thread_snapshot->StackTrace();
+    std::vector<FrameSnapshot> frames;
+    frames.emplace_back(0xfff70001, std::string("uiaeo"));
+    frames.emplace_back(0xfff70002, std::string("snrtdy"));
+
+    for (auto frame_snapshot : frames) {
+      internal::RawFrame frame;
+      frame.instruction_addr = frame_snapshot.InstructionAddr();
+      frame.symbol_offset = symbol_bytes_.size();
+
+      auto symbol = frame_snapshot.Symbol();
+
+      symbol_bytes_.reserve(symbol.size());
+      symbol_bytes_.insert(symbol_bytes_.end(), symbol.begin(), symbol.end());
+
+      frame.symbol_len = symbol.size();
+
+      frames_.push_back(frame);
+    }
+
+    thread.num_frames = frames_.size() - thread.start_frame;
+
+    threads_.push_back(thread);
+  }
+
+  stacktrace_header_.version = 1;
+  stacktrace_header_.num_threads = threads_.size();
+  stacktrace_header_.num_frames = frames_.size();
+  stacktrace_header_.symbol_bytes = symbol_bytes_.size();
+}
+
+size_t MinidumpStacktraceListWriter::SizeOfObject() {
+  DCHECK_GE(state(), kStateFrozen);
+
+  return sizeof(stacktrace_header_) +
+         threads_.size() * sizeof(internal::RawThread) +
+         frames_.size() * sizeof(internal::RawFrame) + symbol_bytes_.size();
+}
+
+size_t MinidumpStacktraceListWriter::Alignment() {
+  // because we are writing `uint64_t` that are 8-byte aligned
+  return 8;
+}
+
+bool MinidumpStacktraceListWriter::WriteObject(
+    FileWriterInterface* file_writer) {
+  DCHECK_EQ(state(), kStateWritable);
+
+  WritableIoVec iov;
+  // header, threads, frames, symbol_bytes
+  std::vector<WritableIoVec> iovecs(4);
+
+  iov.iov_base = &stacktrace_header_;
+  iov.iov_len = sizeof(stacktrace_header_);
+  iovecs.push_back(iov);
+
+  iov.iov_base = &threads_.front();
+  iov.iov_len = threads_.size() * sizeof(internal::RawThread);
+  iovecs.push_back(iov);
+
+  iov.iov_base = &frames_.front();
+  iov.iov_len = frames_.size() * sizeof(internal::RawFrame);
+  iovecs.push_back(iov);
+
+  iov.iov_base = &symbol_bytes_.front();
+  iov.iov_len = symbol_bytes_.size();
+  iovecs.push_back(iov);
+
+  return file_writer->WriteIoVec(&iovecs);
+}
+
+MinidumpStreamType MinidumpStacktraceListWriter::StreamType() const {
+  return kMinidumpStreamTypeSentryStackTraces;
+}
+
+}  // namespace crashpad

--- a/minidump/minidump_stacktrace_writer.h
+++ b/minidump/minidump_stacktrace_writer.h
@@ -1,0 +1,102 @@
+#ifndef CRASHPAD_MINIDUMP_MINIDUMP_STACKTRACE_WRITER_H_
+#define CRASHPAD_MINIDUMP_MINIDUMP_STACKTRACE_WRITER_H_
+
+#include <stdint.h>
+#include <sys/types.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "base/macros.h"
+#include "minidump/minidump_extensions.h"
+#include "minidump/minidump_stream_writer.h"
+#include "minidump/minidump_thread_id_map.h"
+#include "minidump/minidump_writable.h"
+
+namespace crashpad {
+
+namespace internal {
+
+struct Header {
+  uint32_t version;
+  uint32_t num_threads;
+  uint32_t num_frames;
+  uint32_t symbol_bytes;
+};
+
+struct RawThread {
+  uint64_t thread_id;
+  uint32_t start_frame;
+  uint32_t num_frames;
+};
+
+struct RawFrame {
+  uint64_t instruction_addr;
+  uint32_t symbol_offset;
+  uint32_t symbol_len;
+};
+
+}  // namespace internal
+
+// TODO: Create a stub that will later return a real stack trace:
+// `ThreadSnapshot.StackTrace` would need to return a
+// `const std::vector<const FrameSnapshot*>&`, so that followup will also move
+// that type to a more appropriate place.
+// That would be https://getsentry.atlassian.net/browse/NATIVE-198
+class FrameSnapshot {
+ public:
+  FrameSnapshot(uint64_t instruction_addr, std::string symbol)
+      : instruction_addr_(instruction_addr), symbol_(symbol) {}
+
+  uint64_t InstructionAddr() const { return instruction_addr_; };
+  const std::string& Symbol() const { return symbol_; };
+
+ private:
+  uint64_t instruction_addr_;
+  std::string symbol_;
+};
+
+class ThreadSnapshot;
+
+//! \brief The writer for our custom client-side stacktraces stream in a
+//! minidump file.
+class MinidumpStacktraceListWriter final
+    : public internal::MinidumpStreamWriter {
+ public:
+  MinidumpStacktraceListWriter();
+  ~MinidumpStacktraceListWriter() override;
+
+  //! \brief  TODO
+  //!
+  //! \param[in] thread_snapshots The thread snapshots to use as source data.
+  //! \param[in] thread_id_map A MinidumpThreadIDMap to be consulted to
+  //!     determine the 32-bit minidump thread ID to use for the thread
+  //!     identified by \a thread_snapshots.
+  void InitializeFromSnapshot(
+      const std::vector<const ThreadSnapshot*>& thread_snapshots,
+      const MinidumpThreadIDMap& thread_id_map);
+
+ protected:
+  // MinidumpWritable:
+  // bool Freeze() override;
+  size_t SizeOfObject() override;
+  size_t Alignment() override;
+  // std::vector<MinidumpWritable*> Children() override;
+  bool WriteObject(FileWriterInterface* file_writer) override;
+
+  // MinidumpStreamWriter:
+  MinidumpStreamType StreamType() const override;
+
+ private:
+  std::vector<internal::RawThread> threads_;
+  std::vector<internal::RawFrame> frames_;
+  std::vector<uint8_t> symbol_bytes_;
+  internal::Header stacktrace_header_;
+
+  DISALLOW_COPY_AND_ASSIGN(MinidumpStacktraceListWriter);
+};
+
+}  // namespace crashpad
+
+#endif  // CRASHPAD_MINIDUMP_MINIDUMP_STACKTRACE_WRITER_H_

--- a/minidump/minidump_stacktrace_writer.h
+++ b/minidump/minidump_stacktrace_writer.h
@@ -26,7 +26,7 @@ struct Header {
 };
 
 struct RawThread {
-  uint64_t thread_id;
+  uint32_t thread_id;
   uint32_t start_frame;
   uint32_t num_frames;
 };


### PR DESCRIPTION
This creates the infrastructure that allows writing our custom minidump extension that will later on be used to transmit client-side stack traces to symbolicator