### PR TITLE
feat: Create a stub on ThreadSnapshot that will in the future return client-side stack traces (NATIVE-198)

### DIFF
--- a/minidump/minidump_stacktrace_writer.cc
+++ b/minidump/minidump_stacktrace_writer.cc
@@ -47,10 +47,7 @@ void MinidumpStacktraceListWriter::InitializeFromSnapshot(
     thread.thread_id = thread_id_it->second;
     thread.start_frame = (uint32_t)frames_.size();
 
-    // TODO: Create a stub that will later return a real stack trace:
-    // That would be https://getsentry.atlassian.net/browse/NATIVE-198
-    // auto frames = thread_snapshot->StackTrace();
-    std::vector<FrameSnapshot> frames;
+    std::vector<FrameSnapshot> frames = thread_snapshot->StackTrace();
 
     for (auto frame_snapshot : frames) {
       internal::RawFrame frame;

--- a/minidump/minidump_stacktrace_writer.h
+++ b/minidump/minidump_stacktrace_writer.h
@@ -39,24 +39,6 @@ struct RawFrame {
 
 }  // namespace internal
 
-// TODO: Create a stub that will later return a real stack trace:
-// `ThreadSnapshot.StackTrace` would need to return a
-// `const std::vector<const FrameSnapshot*>&`, so that followup will also move
-// that type to a more appropriate place.
-// That would be https://getsentry.atlassian.net/browse/NATIVE-198
-class FrameSnapshot {
- public:
-  FrameSnapshot(uint64_t instruction_addr, std::string symbol)
-      : instruction_addr_(instruction_addr), symbol_(symbol) {}
-
-  uint64_t InstructionAddr() const { return instruction_addr_; };
-  const std::string& Symbol() const { return symbol_; };
-
- private:
-  uint64_t instruction_addr_;
-  std::string symbol_;
-};
-
 class ThreadSnapshot;
 
 //! \brief The writer for our custom client-side stacktraces stream in a

--- a/snapshot/thread_snapshot.h
+++ b/snapshot/thread_snapshot.h
@@ -18,6 +18,7 @@
 #include <stdint.h>
 
 #include <vector>
+#include <string>
 
 namespace crashpad {
 

--- a/snapshot/thread_snapshot.h
+++ b/snapshot/thread_snapshot.h
@@ -98,7 +98,6 @@ class ThreadSnapshot {
   //!     were obtained from.
   virtual std::vector<const MemorySnapshot*> ExtraMemory() const = 0;
 
-  // TODO: This should return a `const std::vector<FrameSnapshot>&`.
   const std::vector<FrameSnapshot>& StackTrace() const {
     return frames_;
   }

--- a/snapshot/thread_snapshot.h
+++ b/snapshot/thread_snapshot.h
@@ -24,10 +24,33 @@ namespace crashpad {
 struct CPUContext;
 class MemorySnapshot;
 
+// TODO: Create a stub that will later return a real stack trace:
+// `ThreadSnapshot.StackTrace` would need to return a
+// `const std::vector<FrameSnapshot>&`.
+// That would be https://getsentry.atlassian.net/browse/NATIVE-198
+class FrameSnapshot {
+ public:
+  FrameSnapshot(uint64_t instruction_addr, std::string symbol)
+      : instruction_addr_(instruction_addr), symbol_(symbol) {}
+
+  uint64_t InstructionAddr() const { return instruction_addr_; };
+  const std::string& Symbol() const { return symbol_; };
+
+ private:
+  uint64_t instruction_addr_;
+  std::string symbol_;
+};
+
 //! \brief An abstract interface to a snapshot representing a thread
 //!     (lightweight process) present in a snapshot process.
 class ThreadSnapshot {
  public:
+  ThreadSnapshot() {
+    frames_ = std::vector<FrameSnapshot>();
+    frames_.emplace_back(0xfff70001, std::string("uiaeo"));
+    frames_.emplace_back(0xfff70002, std::string("snrtdy"));
+  }
+
   virtual ~ThreadSnapshot() {}
 
   //! \brief Returns a CPUContext object corresponding to the thread’s CPU
@@ -73,6 +96,15 @@ class ThreadSnapshot {
   //!     are scoped to the lifetime of the ThreadSnapshot object that they
   //!     were obtained from.
   virtual std::vector<const MemorySnapshot*> ExtraMemory() const = 0;
+
+  // TODO: This should return a `const std::vector<FrameSnapshot>&`.
+  const std::vector<FrameSnapshot>& StackTrace() const {
+    return frames_;
+  }
+
+  private:
+   std::vector<FrameSnapshot> frames_;
+
 };
 
 }  // namespace crashpad

--- a/snapshot/thread_snapshot.h
+++ b/snapshot/thread_snapshot.h
@@ -46,11 +46,7 @@ class FrameSnapshot {
 //!     (lightweight process) present in a snapshot process.
 class ThreadSnapshot {
  public:
-  ThreadSnapshot() {
-    frames_ = std::vector<FrameSnapshot>();
-    frames_.emplace_back(0xfff70001, std::string("uiaeo"));
-    frames_.emplace_back(0xfff70002, std::string("snrtdy"));
-  }
+  ThreadSnapshot() : frames_() {}
 
   virtual ~ThreadSnapshot() {}
 
@@ -102,7 +98,7 @@ class ThreadSnapshot {
     return frames_;
   }
 
-  private:
+  protected:
    std::vector<FrameSnapshot> frames_;
 
 };

--- a/snapshot/thread_snapshot.h
+++ b/snapshot/thread_snapshot.h
@@ -25,10 +25,6 @@ namespace crashpad {
 struct CPUContext;
 class MemorySnapshot;
 
-// TODO: Create a stub that will later return a real stack trace:
-// `ThreadSnapshot.StackTrace` would need to return a
-// `const std::vector<FrameSnapshot>&`.
-// That would be https://getsentry.atlassian.net/browse/NATIVE-198
 class FrameSnapshot {
  public:
   FrameSnapshot(uint64_t instruction_addr, std::string symbol)


### PR DESCRIPTION
This moves `FrameSnapshot` to `thread_snapshot.h` and gives `ThreadSnapshot` a `StackTrace` method that returns a reference to a vector of `FrameSnapshot`s. The intention down the road is for this method to be virtual and implemented by the various platform-specific `ThreadSnapshot`s. For testing purposes, however, we're giving `ThreadSnapshot` a fixed vector of `FrameSnapshot`s as a member.