### PR TITLE
feat: Add remote unwinding to libunwind (NATIVE-151)

### DIFF
--- a/libunwind/include/libunwind.h
+++ b/libunwind/include/libunwind.h
@@ -19,6 +19,9 @@
 #include <stddef.h>
 
 #ifdef __APPLE__
+
+  #include <mach/mach_types.h>
+
   #if __clang__
     #if __has_include(<Availability.h>)
       #include <Availability.h>
@@ -129,6 +132,13 @@ extern int unw_get_proc_name(unw_cursor_t *, char *, size_t, unw_word_t *) LIBUN
 //extern int       unw_get_save_loc(unw_cursor_t*, int, unw_save_loc_t*);
 
 extern unw_addr_space_t unw_local_addr_space;
+
+/*
+ * Mac OS X "remote" API for unwinding other processes on same machine
+ */
+extern unw_addr_space_t unw_create_addr_space_for_task(task_t);
+extern void unw_destroy_addr_space(unw_addr_space_t);
+extern int unw_init_remote_thread(unw_cursor_t *, unw_addr_space_t, thread_t);
 
 #ifdef __cplusplus
 }

--- a/libunwind/src/AddressSpace.hpp
+++ b/libunwind/src/AddressSpace.hpp
@@ -634,10 +634,10 @@ inline bool LocalAddressSpace::findFunctionName(pint_t addr, char *buf,
 struct found_mach_info {
   struct mach_header_64 header;
   struct segment_command_64 segment;
-  size_t ptr_after_segment;
-  size_t load_addr;
-  size_t slide;
-  size_t text_size;
+  uintptr_t ptr_after_segment;
+  uintptr_t load_addr;
+  uintptr_t slide;
+  uintptr_t text_size;
   bool header_valid;
   bool segment_valid;
 };
@@ -657,32 +657,32 @@ public:
   typedef uintptr_t pint_t;
   typedef intptr_t sint_t;
   uint8_t get8(pint_t addr) {
-    uint8_t val;
+    uint8_t val = 0;
     memcpy_from_remote(&val, (void *)addr, sizeof(val));
     return val;
   }
   uint16_t get16(pint_t addr) {
-    uint16_t val;
+    uint16_t val = 0;
     memcpy_from_remote(&val, (void *)addr, sizeof(val));
     return val;
   }
   uint32_t get32(pint_t addr) {
-    uint32_t val;
+    uint32_t val = 0;
     memcpy_from_remote(&val, (void *)addr, sizeof(val));
     return val;
   }
   uint64_t get64(pint_t addr) {
-    uint64_t val;
+    uint64_t val = 0;
     memcpy_from_remote(&val, (void *)addr, sizeof(val));
     return val;
   }
   double getDouble(pint_t addr) {
-    double val;
+    double val = 0;
     memcpy_from_remote(&val, (void *)addr, sizeof(val));
     return val;
   }
   v128 getVector(pint_t addr) {
-    v128 val;
+    v128 val = {0};
     memcpy_from_remote(&val, (void *)addr, sizeof(val));
     return val;
   }
@@ -721,7 +721,7 @@ private:
 
 uint64_t RemoteAddressSpace::getULEB128(pint_t &addr, pint_t end) {
   uintptr_t size = (end - addr);
-  char buf[16];
+  char buf[16] = {0};
   memcpy_from_remote(buf, (void *)addr, 16);
   LocalAddressSpace::pint_t laddr = (LocalAddressSpace::pint_t)buf;
   LocalAddressSpace::pint_t sladdr = laddr;
@@ -732,7 +732,7 @@ uint64_t RemoteAddressSpace::getULEB128(pint_t &addr, pint_t end) {
 
 int64_t RemoteAddressSpace::getSLEB128(pint_t &addr, pint_t end) {
   uintptr_t size = (end - addr);
-  char buf[16];
+  char buf[16] = {0};
   memcpy_from_remote(buf, (void *)addr, 16);
   LocalAddressSpace::pint_t laddr =
       (LocalAddressSpace::pint_t)buf;
@@ -945,7 +945,7 @@ bool RemoteAddressSpace::findMachSegmentInImage(pint_t targetAddr, const char*se
         last_found_image.text_size = seg.vmsize;
         found_text = true;
       }
-      if (strcmp(seg.segname, segment) == 0) {
+      if (strncmp(seg.segname, segment, 16) == 0) {
         pint_t sect_ptr = cmd_ptr + sizeof(struct segment_command_64);
         last_found_image.segment_valid = true;
         last_found_image.segment = seg;
@@ -968,6 +968,8 @@ inline bool RemoteAddressSpace::findUnwindSections(pint_t targetAddr,
   }
 
   info.dso_base = last_found_image.load_addr;
+  info.dwarf_section = 0;
+  info.compact_unwind_section = 0;
 
   for (size_t s = 0; s < last_found_image.segment.nsects; s++) {
     struct section_64 sect;
@@ -1021,8 +1023,8 @@ bool RemoteAddressSpace::findFunctionName(pint_t addr, char *buf,
         return false;
       };
 
-      size_t strtab = last_found_image.load_addr + seg.stroff;
-      size_t nearest_sym = 0;
+      pint_t strtab = last_found_image.load_addr + seg.stroff;
+      pint_t nearest_sym = 0;
       for (size_t s = 0; s < seg.nsyms; s++) {
         struct nlist_64 nlist;
         if (memcpy_from_remote(&nlist,
@@ -1038,10 +1040,10 @@ bool RemoteAddressSpace::findFunctionName(pint_t addr, char *buf,
           continue;
         }
 
-        size_t sym_addr = nlist.n_value + last_found_image.slide;
+        pint_t sym_addr = nlist.n_value + last_found_image.slide;
         if (sym_addr > nearest_sym && sym_addr < addr) {
-          size_t symbol_start = strtab + nlist.n_un.n_strx;
-          size_t bytes_to_copy = strtab + seg.strsize - symbol_start;
+          pint_t symbol_start = strtab + nlist.n_un.n_strx;
+          pint_t bytes_to_copy = strtab + seg.strsize - symbol_start;
           if (bytes_to_copy > bufLen) {
             bytes_to_copy = bufLen;
           }

--- a/libunwind/src/AddressSpace.hpp
+++ b/libunwind/src/AddressSpace.hpp
@@ -47,6 +47,12 @@ struct EHABIIndexEntry {
 
 #ifdef __APPLE__
 
+  #include <mach-o/dyld_images.h>
+  #include <mach-o/loader.h>
+  #include <mach-o/nlist.h>
+  #include <mach/mach_vm.h>
+  #include <mach/task_info.h>
+
   struct dyld_unwind_sections
   {
     const struct mach_header*   mh;
@@ -622,6 +628,440 @@ inline bool LocalAddressSpace::findFunctionName(pint_t addr, char *buf,
   (void)bufLen;
   (void)offset;
 #endif
+  return false;
+}
+
+struct found_mach_info {
+  struct mach_header_64 header;
+  struct segment_command_64 segment;
+  size_t ptr_after_segment;
+  size_t load_addr;
+  size_t slide;
+  size_t text_size;
+  bool header_valid;
+  bool segment_valid;
+};
+
+/// RemoteAddressSpace is used as a template parameter to UnwindCursor when
+/// unwinding a thread in the another process.
+/// In theory, the other process can be a different endianness and a different
+/// pointer size which was handled by the P template parameter in the original
+/// implementation.
+/// However, we assume that we are only dealing with x64 and arm64 here, which
+/// have both the same endianness and pointer size.
+class RemoteAddressSpace {
+public:
+  RemoteAddressSpace(task_t task) : task_(task), last_found_image(found_mach_info()) {}
+  static void *operator new(size_t, RemoteAddressSpace *p) { return p; }
+
+  typedef uintptr_t pint_t;
+  typedef intptr_t sint_t;
+  uint8_t get8(pint_t addr) {
+    uint8_t val;
+    memcpy_from_remote(&val, (void *)addr, sizeof(val));
+    return val;
+  }
+  uint16_t get16(pint_t addr) {
+    uint16_t val;
+    memcpy_from_remote(&val, (void *)addr, sizeof(val));
+    return val;
+  }
+  uint32_t get32(pint_t addr) {
+    uint32_t val;
+    memcpy_from_remote(&val, (void *)addr, sizeof(val));
+    return val;
+  }
+  uint64_t get64(pint_t addr) {
+    uint64_t val;
+    memcpy_from_remote(&val, (void *)addr, sizeof(val));
+    return val;
+  }
+  double getDouble(pint_t addr) {
+    double val;
+    memcpy_from_remote(&val, (void *)addr, sizeof(val));
+    return val;
+  }
+  v128 getVector(pint_t addr) {
+    v128 val;
+    memcpy_from_remote(&val, (void *)addr, sizeof(val));
+    return val;
+  }
+
+  uintptr_t getP(pint_t addr) {
+    return get64(addr);
+  }
+  uint64_t getRegister(pint_t addr) {
+    return get64(addr);
+  }
+
+  uint64_t getULEB128(pint_t &addr, pint_t end);
+  int64_t getSLEB128(pint_t &addr, pint_t end);
+
+  pint_t getEncodedP(pint_t &addr, pint_t end, uint8_t encoding,
+                     pint_t datarelBase = 0);
+  bool findFunctionName(pint_t addr, char *buf, size_t bufLen,
+                        unw_word_t *offset);
+  bool findUnwindSections(pint_t targetAddr, UnwindInfoSections &info);
+  bool findOtherFDE(pint_t targetAddr, pint_t &fde);
+
+private:
+  kern_return_t memcpy_from_remote(void *dest, void *src, size_t size);
+
+  // Finds the mach image that contains `targetAddr`, and saves it and the
+  // corresponding `segment` in the local `last_found_image`, returning `true`
+  // on success.
+  bool findMachSegment(pint_t targetAddr, const char *segment);
+  // Similar to the above, except it assumes the `header` of `last_found_image`
+  // is valid.
+  bool findMachSegmentInImage(pint_t targetAddr, const char *segment);
+
+  task_t task_;
+  found_mach_info last_found_image;
+};
+
+uint64_t RemoteAddressSpace::getULEB128(pint_t &addr, pint_t end) {
+  uintptr_t size = (end - addr);
+  char buf[16];
+  memcpy_from_remote(buf, (void *)addr, 16);
+  LocalAddressSpace::pint_t laddr = (LocalAddressSpace::pint_t)buf;
+  LocalAddressSpace::pint_t sladdr = laddr;
+  uint64_t result = LocalAddressSpace::getULEB128(laddr, laddr + size);
+  addr += (laddr - sladdr);
+  return result;
+}
+
+int64_t RemoteAddressSpace::getSLEB128(pint_t &addr, pint_t end) {
+  uintptr_t size = (end - addr);
+  char buf[16];
+  memcpy_from_remote(buf, (void *)addr, 16);
+  LocalAddressSpace::pint_t laddr =
+      (LocalAddressSpace::pint_t)buf;
+  LocalAddressSpace::pint_t sladdr = laddr;
+  int64_t result = LocalAddressSpace::getSLEB128(laddr, laddr + size);
+  addr += (laddr - sladdr);
+  return result;
+}
+
+kern_return_t RemoteAddressSpace::memcpy_from_remote(void *dest, void *src, size_t size) {
+  size_t read_bytes = 0;
+  kern_return_t kr = mach_vm_read_overwrite(
+      task_, (mach_vm_address_t)src, (mach_vm_size_t)size,
+      (mach_vm_address_t)dest, (mach_vm_size_t *)&read_bytes);
+  return kr;
+}
+
+// we needed to copy this whole function since we can’t reuse the one from
+// `LocalAddressSpace`. :-(
+RemoteAddressSpace::pint_t
+RemoteAddressSpace::getEncodedP(pint_t &addr, pint_t end, uint8_t encoding,
+                                pint_t datarelBase) {
+  pint_t startAddr = addr;
+  const uint8_t *p = (uint8_t *)addr;
+  pint_t result;
+
+  // first get value
+  switch (encoding & 0x0F) {
+  case DW_EH_PE_ptr:
+    result = getP(addr);
+    p += sizeof(pint_t);
+    addr = (pint_t)p;
+    break;
+  case DW_EH_PE_uleb128:
+    result = (pint_t)getULEB128(addr, end);
+    break;
+  case DW_EH_PE_udata2:
+    result = get16(addr);
+    p += 2;
+    addr = (pint_t)p;
+    break;
+  case DW_EH_PE_udata4:
+    result = get32(addr);
+    p += 4;
+    addr = (pint_t)p;
+    break;
+  case DW_EH_PE_udata8:
+    result = (pint_t)get64(addr);
+    p += 8;
+    addr = (pint_t)p;
+    break;
+  case DW_EH_PE_sleb128:
+    result = (pint_t)getSLEB128(addr, end);
+    break;
+  case DW_EH_PE_sdata2:
+    // Sign extend from signed 16-bit value.
+    result = (pint_t)(int16_t)get16(addr);
+    p += 2;
+    addr = (pint_t)p;
+    break;
+  case DW_EH_PE_sdata4:
+    // Sign extend from signed 32-bit value.
+    result = (pint_t)(int32_t)get32(addr);
+    p += 4;
+    addr = (pint_t)p;
+    break;
+  case DW_EH_PE_sdata8:
+    result = (pint_t)get64(addr);
+    p += 8;
+    addr = (pint_t)p;
+    break;
+  default:
+    _LIBUNWIND_ABORT("unknown pointer encoding");
+  }
+
+  // then add relative offset
+  switch (encoding & 0x70) {
+  case DW_EH_PE_absptr:
+    // do nothing
+    break;
+  case DW_EH_PE_pcrel:
+    result += startAddr;
+    break;
+  case DW_EH_PE_textrel:
+    _LIBUNWIND_ABORT("DW_EH_PE_textrel pointer encoding not supported");
+    break;
+  case DW_EH_PE_datarel:
+    // DW_EH_PE_datarel is only valid in a few places, so the parameter has a
+    // default value of 0, and we abort in the event that someone calls this
+    // function with a datarelBase of 0 and DW_EH_PE_datarel encoding.
+    if (datarelBase == 0)
+      _LIBUNWIND_ABORT("DW_EH_PE_datarel is invalid with a datarelBase of 0");
+    result += datarelBase;
+    break;
+  case DW_EH_PE_funcrel:
+    _LIBUNWIND_ABORT("DW_EH_PE_funcrel pointer encoding not supported");
+    break;
+  case DW_EH_PE_aligned:
+    _LIBUNWIND_ABORT("DW_EH_PE_aligned pointer encoding not supported");
+    break;
+  default:
+    _LIBUNWIND_ABORT("unknown pointer encoding");
+    break;
+  }
+
+  if (encoding & DW_EH_PE_indirect)
+    result = getP(result);
+
+  return result;
+}
+
+bool RemoteAddressSpace::findMachSegment(pint_t targetAddr,
+                                                const char *segment) {
+  if (!last_found_image.header_valid || !(last_found_image.load_addr <= targetAddr && last_found_image.load_addr + last_found_image.text_size > targetAddr)) {
+    last_found_image.segment_valid = false;
+    // enumerate all images and find the one we are looking for.
+
+    task_dyld_info_data_t task_dyld_info;
+    mach_msg_type_number_t count = TASK_DYLD_INFO_COUNT;
+    if (task_info(task_, TASK_DYLD_INFO, (task_info_t)&task_dyld_info,
+                  &count) != KERN_SUCCESS) {
+      return false;
+    }
+    if (task_dyld_info.all_image_info_format != TASK_DYLD_ALL_IMAGE_INFO_64) {
+      return false;
+    }
+
+    dyld_all_image_infos all_images_info;
+    if (memcpy_from_remote(&all_images_info,
+                           (void *)task_dyld_info.all_image_info_addr,
+                           sizeof(dyld_all_image_infos)) != KERN_SUCCESS) {
+      return false;
+    };
+
+    for (size_t i = 0; i < all_images_info.infoArrayCount; i++) {
+      dyld_image_info image;
+      if (memcpy_from_remote(&image, (void *)&all_images_info.infoArray[i],
+                             sizeof(dyld_image_info)) != KERN_SUCCESS) {
+        continue;
+      };
+
+      // image is out of range of `targetAddr`
+      if ((pint_t)image.imageLoadAddress > targetAddr) {
+        continue;
+      }
+
+      if (memcpy_from_remote(&last_found_image.header,
+                             (void *)image.imageLoadAddress,
+                             sizeof(struct mach_header_64)) != KERN_SUCCESS) {
+        continue;
+      };
+
+      if (last_found_image.header.magic != MH_MAGIC_64) {
+        continue;
+      }
+
+      last_found_image.load_addr = (size_t)image.imageLoadAddress;
+      if (findMachSegmentInImage(targetAddr, "__TEXT")) {
+        last_found_image.header_valid = true;
+        break;
+      }
+    }
+  }
+
+  if (!last_found_image.header_valid) {
+    return false;
+  }
+
+  if (!last_found_image.segment_valid ||
+      strcmp(last_found_image.segment.segname, segment) != 0) {
+    // search for the segment in the image
+    if (!findMachSegmentInImage(targetAddr, segment)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool RemoteAddressSpace::findMachSegmentInImage(pint_t targetAddr, const char*segment) {
+  // This section here is basically a remote-rewrite of
+  // `dyld_exceptions_init` from:
+  // https://opensource.apple.com/source/dyld/dyld-195.6/src/dyldExceptions.c.auto.html
+  struct load_command cmd;
+  pint_t cmd_ptr =
+      (pint_t)last_found_image.load_addr + sizeof(struct mach_header_64);
+  bool found_text = false;
+  bool found_searched = false;
+  for (size_t c = 0; c < last_found_image.header.ncmds; c++) {
+    if (memcpy_from_remote(&cmd, (void *)cmd_ptr,
+                           sizeof(struct load_command)) != KERN_SUCCESS) {
+      return false;
+    };
+    if (cmd.cmd == LC_SEGMENT_64) {
+      struct segment_command_64 seg;
+      if (memcpy_from_remote(&seg, (void *)cmd_ptr,
+                             sizeof(struct segment_command_64)) !=
+          KERN_SUCCESS) {
+        return false;
+      };
+
+      if (strcmp(seg.segname, "__TEXT") == 0) {
+        pint_t slide = last_found_image.load_addr - seg.vmaddr;
+
+        // text section out of range of `targetAddr`
+        pint_t text_end = seg.vmaddr + seg.vmsize + slide;
+        if (text_end < targetAddr) {
+          return false;
+        }
+        last_found_image.slide = slide;
+        last_found_image.text_size = seg.vmsize;
+        found_text = true;
+      }
+      if (strcmp(seg.segname, segment) == 0) {
+        pint_t sect_ptr = cmd_ptr + sizeof(struct segment_command_64);
+        last_found_image.segment_valid = true;
+        last_found_image.segment = seg;
+        last_found_image.ptr_after_segment = sect_ptr;
+        found_searched = true;
+      }
+      if (found_text && found_searched) {
+        return true;
+      }
+    }
+    cmd_ptr += cmd.cmdsize;
+  }
+  return false;
+}
+
+inline bool RemoteAddressSpace::findUnwindSections(pint_t targetAddr,
+                                                   UnwindInfoSections &info) {
+  if (!findMachSegment(targetAddr, "__TEXT")) {
+    return false;
+  }
+
+  info.dso_base = last_found_image.load_addr;
+
+  for (size_t s = 0; s < last_found_image.segment.nsects; s++) {
+    struct section_64 sect;
+    if (memcpy_from_remote(&sect,
+                           (void *)(last_found_image.ptr_after_segment +
+                                    s * sizeof(struct section_64)),
+                           sizeof(struct section_64)) != KERN_SUCCESS) {
+      continue;
+    };
+
+    if (strcmp(sect.sectname, "__eh_frame") == 0) {
+      info.dwarf_section = sect.addr + last_found_image.slide;
+      info.dwarf_section_length = sect.size;
+    } else if (strcmp(sect.sectname, "__unwind_info") == 0) {
+      info.compact_unwind_section = sect.addr + last_found_image.slide;
+      info.compact_unwind_section_length = sect.size;
+    }
+  }
+  return true;
+}
+
+bool RemoteAddressSpace::findOtherFDE(pint_t targetAddr, pint_t & fde) {
+  // TO DO: if OS has way to dynamically register FDEs, check that.
+  (void)targetAddr;
+  (void)fde;
+  return false;
+}
+
+bool RemoteAddressSpace::findFunctionName(pint_t addr, char *buf,
+                                          size_t bufLen, unw_word_t *offset) {
+  // This is essentially a remote re-implementation of this snippet:
+  // https://gist.github.com/integeruser/b0d3ea6c4e8387d036acf6c77c0ec406
+
+  if (!findMachSegment(addr, "__TEXT")) {
+    return false;
+  }
+
+  struct load_command cmd;
+  pint_t cmd_ptr =
+      (pint_t)last_found_image.load_addr + sizeof(struct mach_header_64);
+  for (size_t c = 0; c < last_found_image.header.ncmds; c++) {
+    if (memcpy_from_remote(&cmd, (void *)cmd_ptr,
+                           sizeof(struct load_command)) != KERN_SUCCESS) {
+      return false;
+    };
+
+    if (cmd.cmd == LC_SYMTAB) {
+      struct symtab_command seg;
+      if (memcpy_from_remote(&seg, (void *)cmd_ptr,
+                             sizeof(struct symtab_command)) != KERN_SUCCESS) {
+        return false;
+      };
+
+      size_t strtab = last_found_image.load_addr + seg.stroff;
+      size_t nearest_sym = 0;
+      for (size_t s = 0; s < seg.nsyms; s++) {
+        struct nlist_64 nlist;
+        if (memcpy_from_remote(&nlist,
+                               (void *)(last_found_image.load_addr +
+                                        seg.symoff +
+                                        s * sizeof(struct nlist_64)),
+                               sizeof(struct nlist_64)) != KERN_SUCCESS) {
+          return false;
+        };
+
+        if ((nlist.n_type & N_STAB) != 0 || (nlist.n_type & N_TYPE) != N_SECT ||
+            nlist.n_un.n_strx == 0) {
+          continue;
+        }
+
+        size_t sym_addr = nlist.n_value + last_found_image.slide;
+        if (sym_addr > nearest_sym && sym_addr < addr) {
+          size_t symbol_start = strtab + nlist.n_un.n_strx;
+          size_t bytes_to_copy = strtab + seg.strsize - symbol_start;
+          if (bytes_to_copy > bufLen) {
+            bytes_to_copy = bufLen;
+          }
+          if (memcpy_from_remote(buf, (void *)(symbol_start), bytes_to_copy) !=
+              KERN_SUCCESS) {
+            return false;
+          }
+          buf[bufLen - 1] = '\0';
+          nearest_sym = sym_addr;
+        }
+      }
+      if (nearest_sym > 0) {
+        return true;
+      }
+      break;
+    }
+    cmd_ptr += cmd.cmdsize;
+  }
+
+  (void)offset;
   return false;
 }
 


### PR DESCRIPTION
This patches our vendored libunwind version to support remote unwinding
on macOS.

More specifically, this revives some previously existing, but never
finished or working code, which was removed in
https://github.com/llvm/llvm-project/commit/368c02e3ec44e5418626f46abebcc22a69c7f66d