### PR TITLE
feat: Build vendored libunwind (NATIVE-274)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,11 @@ add_subdirectory(third_party/getopt)
 add_subdirectory(tools)
 add_subdirectory(handler)
 
+if(CRASHPAD_ENABLE_STACKTRACE AND APPLE)
+    set(LIBUNWIND_ENABLE_SHARED OFF)
+    add_subdirectory(libunwind)
+endif()
+
 if(CRASHPAD_ENABLE_INSTALL_DEV)
     install(EXPORT crashpad_export NAMESPACE crashpad:: FILE crashpad-targets.cmake
         DESTINATION "${CMAKE_INSTALL_CMAKEDIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ add_subdirectory(third_party/getopt)
 add_subdirectory(tools)
 add_subdirectory(handler)
 
-if(CRASHPAD_ENABLE_STACKTRACE AND APPLE)
+if(CRASHPAD_ENABLE_STACKTRACE AND APPLE AND NOT IOS)
     set(LIBUNWIND_ENABLE_SHARED OFF)
     add_subdirectory(libunwind)
 endif()

--- a/libunwind/CMakeLists.txt
+++ b/libunwind/CMakeLists.txt
@@ -1,7 +1,3 @@
-if (NOT IS_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/../libcxx")
-  message(FATAL_ERROR "libunwind requires being built in a monorepo layout with libcxx available")
-endif()
-
 #===============================================================================
 # Setup Project
 #===============================================================================


### PR DESCRIPTION
This builds the vendored copy of libunwind on macOS when
CRASHPAD_ENABLE_STACKTRACE is enabled.