### PR TITLE
msvc: Install getopt target and link crashpad handler library with getopt.

### DIFF
--- a/handler/CMakeLists.txt
+++ b/handler/CMakeLists.txt
@@ -64,6 +64,7 @@ target_link_libraries(crashpad_handler_lib
 
 if(WIN32)
     if(MSVC)
+        target_link_libraries(crashpad_handler_lib PUBLIC crashpad_getopt)
         target_compile_options(crashpad_handler_lib PRIVATE "/wd4201")
     endif()
 endif()

--- a/third_party/getopt/CMakeLists.txt
+++ b/third_party/getopt/CMakeLists.txt
@@ -9,6 +9,7 @@ if(MSVC)
     target_link_libraries(crashpad_getopt PRIVATE
         $<BUILD_INTERFACE:crashpad_interface>
     )
+    crashpad_install_target(crashpad_getopt)
 else()
     add_library(crashpad_getopt INTERFACE)
 endif()


### PR DESCRIPTION
The `crashpad_handler` library uses getopt functionality in `HandlerMain` function. Hence when implementing your own crash handler instead of using bundled handler program the getopt library needs to be linked in as well.