### PR TITLE
Don't add /Zi to compiler flags with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,6 @@ if(MSVC)
         $<$<COMPILE_LANGUAGE:C,CXX>:/FS>
         $<$<COMPILE_LANGUAGE:C,CXX>:/W4>
         $<$<COMPILE_LANGUAGE:C,CXX>:/WX>
-        $<$<COMPILE_LANGUAGE:C,CXX>:/Zi>
         $<$<COMPILE_LANGUAGE:C,CXX>:/bigobj> # Support larger number of sections in obj file.
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4100> # Unreferenced formal parameter.
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4127> # Conditional expression is constant.


### PR DESCRIPTION
The use of /Zi is incompatible with sccache. By not adding this flag explicitly we rely on the default behavior of cmake which is: add /Zi for builds with build type: debug, relwithdebinfo or unspecified build type. Cmake does not add /Zi for release builds.
