### PR TITLE
fix: Use correct ASM files on Windows ARM64

### DIFF
--- a/third_party/zlib/CMakeLists.txt
+++ b/third_party/zlib/CMakeLists.txt
@@ -35,6 +35,7 @@ else()
         zlib/trees.c
         zlib/trees.h
         zlib/uncompr.c
+        zlib/x86.h
         zlib/zconf.h
         zlib/zlib.h
         zlib/zutil.c
@@ -52,7 +53,6 @@ else()
             zlib/crc_folding.c
             zlib/fill_window_sse.c
             zlib/x86.c
-            zlib/x86.h
         )
 
         if(NOT MSVC)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -339,9 +339,17 @@ if(WIN32)
         win/termination_codes.h
         win/traits.h
         win/xp_compat.h
-        misc/capture_context_win.asm
-        win/safe_terminate_process.asm
     )
+    if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+        target_sources(crashpad_util PRIVATE
+            misc/capture_context_win_arm64.asm
+        )
+    else()
+        target_sources(crashpad_util PRIVATE
+            misc/capture_context_win.asm
+            win/safe_terminate_process.asm
+        )
+    endif()
 endif()
 
 # Copied from: https://github.com/qedsoftware/crashpad/blob/3583c50a6575857abcf140f6ea3b8d11390205b3/util/CMakeLists.txt#L196-L233


### PR DESCRIPTION
Helps with, but does not fully fix https://getsentry.atlassian.net/browse/ISSUE-1336

It seems that the arm64 assembler is not supported by cmake.
See https://stackoverflow.com/questions/59742466/building-arm64-asm-in-visual-studio-with-cmake
Also there is https://gitlab.kitware.com/cmake/cmake/-/issues/15170