### PR TITLE
Expose enabled-flag for WER

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,15 @@ if(MSVC)
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4577> # 'noexcept' used with no exception handling mode specified.
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4996> # 'X' was declared deprecated.
     )
+
+    # WER support is only available starting from Win10 build 10941
+    if(${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION} VERSION_LESS 10.0.19041)
+        message(STATUS "WER support disabled. Needs target platform >= 10.0.19041 (actual: ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION})")
+    else()
+        SET(CRASHPAD_WER_ENABLED TRUE)
+        SET(CRASHPAD_WER_ENABLED TRUE PARENT_SCOPE)
+        message(STATUS "WER support enabled")
+    endif()
 elseif(MINGW)
     # redirect to wmain
     # FIXME: cmake 3.13 added target_link_options

--- a/handler/CMakeLists.txt
+++ b/handler/CMakeLists.txt
@@ -123,7 +123,7 @@ if(NOT IOS)
     )
 endif()
 
-if(WIN32)
+if(CRASHPAD_WER_ENABLED)
     add_library(crashpad_wer SHARED
         win/wer/crashpad_wer.cc
         win/wer/crashpad_wer.h


### PR DESCRIPTION
### Context

From https://github.com/getsentry/crashpad/pull/69/commits/80520bd937021dfc37a67ca027291491120d3f27:

_WerRegisterExceptionHelperModule has been availble since at least
Windows 7 but WerFault would not pass on the exceptions that crashpad
could not already handle. This changed in Windows 10 20H1 (19041),
which supports HKCU and HKLM registrations, and passes in more types of
crashes. It is harmless to register the module for earlier versions
of Windows as it simply won't be loaded by WerFault.exe._

This is about to be integrated into https://github.com/getsentry/sentry-native/pull/735

### Problem

It might be true that registering the module on an older Windows version is without consequence. Still, the current module implementation in crashpad will not build if the Windows target platform is lower than 19041 (raised during our [CI build on 10.0.17763](https://github.com/getsentry/sentry-native/runs/7388227986?check_suite_focus=true#step:10:246) and verified in the 10.0.18363 SDK from the immediate predecessor).

The build fails because crashpad depends on the `bIsFatal` flag of  [WER_RUNTIME_EXCEPTION_INFORMATION](https://docs.microsoft.com/en-us/windows/win32/api/werapi/ns-werapi-wer_runtime_exception_information) in its WER callback to stop processing in case the exception-event was non-fatal. This flag is in the SDK, starting with 19041.

### Solution

This change makes the creation of a WER DLL dependent on the target platform and informs the `PARENT_SCOPE` (the sentry-native project) on whether it enabled it in the build. This allows `sentry-native` to bypass all dependencies on the target. 

### Alternative approaches

The above eliminates the artifact due to a single missing flag. One could argue that the flag is irrelevant in the current implementation because the WER handler accepts to process only two kinds of exception events:

- `STATUS_STACK_BUFFER_OVERRUN`
- `STATUS_FAIL_FAST_EXCEPTION`

both are certainly fatal and will be checked in the next step anyway. We can `#ifdef` the flag-check with `NTDDI_WIN10_VB`, ensuring we target 19041. This would allow people to build for the older target platform but still deploy the WER DLL on a more modern Windows. Doing this also prevents build-failure when a user of sentry-native changes the target platform in Visual Studio after the CMake build-generator runs. The only downsides are

- additional maintenance effort (consider the addition of more exceptions) and 
- the runtime effort of checking all incoming exception codes against the registered exceptions (currently: two)

Of course, creating the WER DLL still doesn't provide any value on older target platforms, so combining both approaches may be a good third option ;-)