### PR TITLE
meta: update 2022-12-12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@
 /third_party/lss/lss
 /third_party/gyp/gyp
 /third_party/mini_chromium/mini_chromium
+/third_party/ninja/linux
+/third_party/ninja/mac*
+/third_party/ninja/ninja.exe
 /third_party/zlib/zlib
 /xcodebuild
 tags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,18 @@ if(CRASHPAD_ZLIB_SYSTEM)
     find_package(ZLIB REQUIRED)
 endif()
 
+
 if(LINUX OR ANDROID)
     find_package(OpenSSL)
     if(OPENSSL_FOUND)
         set(CRASHPAD_USE_BORINGSSL ON)
     endif()
+endif()
+
+if (NOT (ANDROID OR FUCHSIA))
+    add_compile_definitions(CRASHPAD_FLOCK_ALWAYS_SUPPORTED=1)
+else()
+    add_compile_definitions(CRASHPAD_FLOCK_ALWAYS_SUPPORTED=0)
 endif()
 
 include(GNUInstallDirs)

--- a/DEPS
+++ b/DEPS
@@ -168,7 +168,7 @@ deps = {
         'version': Var('ninja_version'),
       }
     ],
-    'condition': 'host_os == "mac" and host_cpu == "amd64"',
+    'condition': 'host_os == "mac" and host_cpu == "x64"',
     'dep_type': 'cipd',
   },
   'crashpad/third_party/ninja/mac-arm64': {

--- a/DEPS
+++ b/DEPS
@@ -15,6 +15,9 @@
 vars = {
   'chromium_git': 'https://chromium.googlesource.com',
   'gn_version': 'git_revision:2ecd43a10266bd091c98e6dcde507c64f6a0dad3',
+  # ninja CIPD package version.
+  # https://chrome-infra-packages.appspot.com/p/infra/3pp/tools/ninja
+  'ninja_version': 'version:2@1.8.2.chromium.3',
   'pull_linux_clang': False,
   'pull_win_toolchain': False,
   # Controls whether crashpad/build/ios/setup-ios-gn.py is run as part of
@@ -132,6 +135,51 @@ deps = {
     ],
     'condition': 'checkout_fuchsia and host_os == "linux"',
     'dep_type': 'cipd'
+  },
+  # depot_tools/ninja wrapper calls third_party/ninja/{ninja, ninja.exe}.
+  # crashpad/third_party/ninja/ninja is another wrapper to call linux ninja
+  # or mac ninja.
+  # This allows crashpad developers to work for multiple platforms on the same
+  # machine.
+  'crashpad/third_party/ninja': {
+    'packages': [
+      {
+        'package': 'infra/3pp/tools/ninja/${{platform}}',
+        'version': Var('ninja_version'),
+      }
+    ],
+    'condition': 'host_os == "win"',
+    'dep_type': 'cipd',
+  },
+  'crashpad/third_party/ninja/linux': {
+    'packages': [
+      {
+        'package': 'infra/3pp/tools/ninja/${{platform}}',
+        'version': Var('ninja_version'),
+      }
+    ],
+    'condition': 'host_os == "linux"',
+    'dep_type': 'cipd',
+  },
+  'crashpad/third_party/ninja/mac-amd64': {
+    'packages': [
+      {
+        'package': 'infra/3pp/tools/ninja/mac-amd64',
+        'version': Var('ninja_version'),
+      }
+    ],
+    'condition': 'host_os == "mac" and host_cpu == "amd64"',
+    'dep_type': 'cipd',
+  },
+  'crashpad/third_party/ninja/mac-arm64': {
+    'packages': [
+      {
+        'package': 'infra/3pp/tools/ninja/mac-arm64',
+        'version': Var('ninja_version'),
+      }
+    ],
+    'condition': 'host_os == "mac" and host_cpu == "arm64"',
+    'dep_type': 'cipd',
   },
   'crashpad/third_party/win/toolchain': {
     # This package is only updated when the solution in .gclient includes an

--- a/build/BUILD.gn
+++ b/build/BUILD.gn
@@ -30,6 +30,12 @@ config("crashpad_is_in_fuchsia") {
   }
 }
 
+config("flock_always_supported_defines") {
+  defines = [
+    "CRASHPAD_FLOCK_ALWAYS_SUPPORTED=$crashpad_flock_always_supported",
+  ]
+}
+
 group("default_exe_manifest_win") {
   if (crashpad_is_in_chromium) {
     deps = [ "//build/win:default_exe_manifest" ]

--- a/build/crashpad_buildconfig.gni
+++ b/build/crashpad_buildconfig.gni
@@ -81,6 +81,8 @@ if (crashpad_is_in_chromium) {
   crashpad_is_clang = mini_chromium_is_clang
 }
 
+crashpad_flock_always_supported = !(crashpad_is_android || crashpad_is_fuchsia)
+
 template("crashpad_executable") {
   executable(target_name) {
     forward_variables_from(invoker,

--- a/client/BUILD.gn
+++ b/client/BUILD.gn
@@ -144,6 +144,7 @@ static_library("common") {
     "../util",
   ]
   deps = [ "../util" ]
+  configs += [ "../build:flock_always_supported_defines" ]
 }
 
 source_set("client_test") {

--- a/client/crash_report_database_generic.cc
+++ b/client/crash_report_database_generic.cc
@@ -549,6 +549,16 @@ int CrashReportDatabaseGeneric::CleanDatabase(time_t lockfile_ttl) {
   removed += CleanReportsInState(kPending, lockfile_ttl);
   removed += CleanReportsInState(kCompleted, lockfile_ttl);
   CleanOrphanedAttachments();
+#if !CRASHPAD_FLOCK_ALWAYS_SUPPORTED
+  base::FilePath settings_path(kSettings);
+  if (Settings::IsLockExpired(settings_path, lockfile_ttl)) {
+    base::FilePath lockfile_path(settings_path.value() +
+                                 Settings::kLockfileExtension);
+    if (LoggingRemoveFile(lockfile_path)) {
+      ++removed;
+    }
+  }
+#endif  // !CRASHPAD_FLOCK_ALWAYS_SUPPORTED
   return removed;
 }
 

--- a/client/crashpad_client_linux.cc
+++ b/client/crashpad_client_linux.cc
@@ -180,8 +180,10 @@ class SignalHandler {
 
     DCHECK(!handler_);
     handler_ = this;
-    return Signals::InstallCrashHandlers(
-        HandleOrReraiseSignal, SA_ONSTACK, &old_actions_, unhandled_signals);
+    return Signals::InstallCrashHandlers(HandleOrReraiseSignal,
+                                         SA_ONSTACK | SA_EXPOSE_TAGBITS,
+                                         &old_actions_,
+                                         unhandled_signals);
   }
 
   const ExceptionInformation& GetExceptionInfo() {

--- a/client/crashpad_client_linux_test.cc
+++ b/client/crashpad_client_linux_test.cc
@@ -268,7 +268,7 @@ class ScopedAltSignalStack {
 
   void Initialize() {
     ScopedMmap local_stack_mem;
-    constexpr size_t stack_size = MINSIGSTKSZ;
+    const size_t stack_size = MINSIGSTKSZ;
     ASSERT_TRUE(local_stack_mem.ResetMmap(nullptr,
                                           stack_size,
                                           PROT_READ | PROT_WRITE,

--- a/client/crashpad_client_linux_test.cc
+++ b/client/crashpad_client_linux_test.cc
@@ -213,6 +213,12 @@ void ValidateDump(const StartHandlerForSelfTestOptions& options,
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winfinite-recursion"
+// Clang (masquerading as gcc) is too smart, and removes the recursion
+// otherwise. May need to change if either clang or another compiler becomes
+// smarter.
+#if defined(COMPILER_GCC)
+__attribute__((noinline))
+#endif
 int RecurseInfinitely(int* ptr) {
   int buf[1 << 20];
   return *ptr + RecurseInfinitely(buf);

--- a/client/crashpad_client_linux_test.cc
+++ b/client/crashpad_client_linux_test.cc
@@ -517,8 +517,7 @@ TEST_P(StartHandlerForSelfTest, StartHandlerInChild) {
   if (Options().crash_type == CrashType::kSegvWithTagBits) {
 #if !defined(ARCH_CPU_ARM64)
     GTEST_SKIP() << "Testing for tag bits only exists on aarch64.";
-#endif  // !defined(ARCH_CPU_ARM64)
-
+#else
     struct utsname uname_info;
     ASSERT_EQ(uname(&uname_info), 0);
     ASSERT_NE(uname_info.release, nullptr);
@@ -532,6 +531,7 @@ TEST_P(StartHandlerForSelfTest, StartHandlerInChild) {
       GTEST_SKIP() << "Linux kernel v" << uname_info.release
                    << " does not support SA_EXPOSE_TAGBITS";
     }
+#endif  // !defined(ARCH_CPU_ARM64)
   }
 
   StartHandlerForSelfInChildTest test(Options());

--- a/client/settings.cc
+++ b/client/settings.cc
@@ -19,6 +19,7 @@
 #include <limits>
 
 #include "base/logging.h"
+#include "base/notreached.h"
 #include "base/posix/eintr_wrapper.h"
 #include "build/build_config.h"
 #include "util/file/filesystem.h"

--- a/client/settings.cc
+++ b/client/settings.cc
@@ -26,7 +26,7 @@
 
 namespace crashpad {
 
-#if BUILDFLAG(IS_FUCHSIA)
+#if !CRASHPAD_FLOCK_ALWAYS_SUPPORTED
 
 Settings::ScopedLockedFileHandle::ScopedLockedFileHandle()
     : handle_(kInvalidFileHandle), lockfile_path_() {
@@ -69,7 +69,7 @@ void Settings::ScopedLockedFileHandle::Destroy() {
   }
 }
 
-#else  // BUILDFLAG(IS_FUCHSIA)
+#else  // !CRASHPAD_FLOCK_ALWAYS_SUPPORTED
 
 #if BUILDFLAG(IS_IOS)
 
@@ -217,25 +217,50 @@ bool Settings::SetLastUploadAttemptTime(time_t time) {
   return WriteSettings(handle.get(), settings);
 }
 
+#if !CRASHPAD_FLOCK_ALWAYS_SUPPORTED
+// static
+bool Settings::IsLockExpired(const base::FilePath& file_path,
+                             time_t lockfile_ttl) {
+  time_t now = time(nullptr);
+  base::FilePath lock_path(file_path.value() + Settings::kLockfileExtension);
+  ScopedFileHandle lock_fd(LoggingOpenFileForRead(lock_path));
+  time_t lock_timestamp;
+  if (!LoggingReadFileExactly(
+          lock_fd.get(), &lock_timestamp, sizeof(lock_timestamp))) {
+    return false;
+  }
+  return now >= lock_timestamp + lockfile_ttl;
+}
+#endif  // !CRASHPAD_FLOCK_ALWAYS_SUPPORTED
+
 // static
 Settings::ScopedLockedFileHandle Settings::MakeScopedLockedFileHandle(
-    FileHandle file,
+    const internal::MakeScopedLockedFileHandleOptions& options,
     FileLocking locking,
     const base::FilePath& file_path) {
-  ScopedFileHandle scoped(file);
-#if BUILDFLAG(IS_FUCHSIA)
-  base::FilePath lockfile_path(file_path.value() + ".__lock__");
+#if !CRASHPAD_FLOCK_ALWAYS_SUPPORTED
+  base::FilePath lockfile_path(file_path.value() +
+                               Settings::kLockfileExtension);
+  ScopedFileHandle lockfile_scoped(
+      LoggingOpenFileForWrite(lockfile_path,
+                              FileWriteMode::kCreateOrFail,
+                              FilePermissions::kWorldReadable));
+  if (!lockfile_scoped.is_valid()) {
+    return ScopedLockedFileHandle();
+  }
+  time_t now = time(nullptr);
+  if (!LoggingWriteFile(lockfile_scoped.get(), &now, sizeof(now))) {
+    return ScopedLockedFileHandle();
+  }
+  ScopedFileHandle scoped(GetHandleFromOptions(file_path, options));
   if (scoped.is_valid()) {
-    ScopedFileHandle lockfile_scoped(
-        LoggingOpenFileForWrite(lockfile_path,
-                                FileWriteMode::kCreateOrFail,
-                                FilePermissions::kWorldReadable));
-    // This is a lightweight attempt to try to catch racy behavior.
-    DCHECK(lockfile_scoped.is_valid());
     return ScopedLockedFileHandle(scoped.release(), lockfile_path);
   }
-  return ScopedLockedFileHandle(scoped.release(), base::FilePath());
+  bool success = LoggingRemoveFile(lockfile_path);
+  DCHECK(success);
+  return ScopedLockedFileHandle();
 #else
+  ScopedFileHandle scoped(GetHandleFromOptions(file_path, options));
   // It's important to create the ScopedLockedFileHandle before calling
   // LoggingLockFile on iOS, so a ScopedBackgroundTask is created *before*
   // the LoggingLockFile call below.
@@ -249,29 +274,50 @@ Settings::ScopedLockedFileHandle Settings::MakeScopedLockedFileHandle(
   }
   handle.reset(scoped.release());
   return handle;
-#endif
+#endif  // !CRASHPAD_FLOCK_ALWAYS_SUPPORTED
+}
+
+// static
+FileHandle Settings::GetHandleFromOptions(
+    const base::FilePath& file_path,
+    const internal::MakeScopedLockedFileHandleOptions& options) {
+  switch (options.function_enum) {
+    case internal::FileOpenFunction::kLoggingOpenFileForRead:
+      return LoggingOpenFileForRead(file_path);
+    case internal::FileOpenFunction::kLoggingOpenFileForReadAndWrite:
+      return LoggingOpenFileForReadAndWrite(
+          file_path, options.mode, options.permissions);
+    case internal::FileOpenFunction::kOpenFileForReadAndWrite:
+      return OpenFileForReadAndWrite(
+          file_path, options.mode, options.permissions);
+  }
+  NOTREACHED();
+  return kInvalidFileHandle;
 }
 
 Settings::ScopedLockedFileHandle Settings::OpenForReading() {
-  return MakeScopedLockedFileHandle(
-      LoggingOpenFileForRead(file_path()), FileLocking::kShared, file_path());
+  internal::MakeScopedLockedFileHandleOptions options;
+  options.function_enum = internal::FileOpenFunction::kLoggingOpenFileForRead;
+  return MakeScopedLockedFileHandle(options, FileLocking::kShared, file_path());
 }
 
 Settings::ScopedLockedFileHandle Settings::OpenForReadingAndWriting(
     FileWriteMode mode, bool log_open_error) {
   DCHECK(mode != FileWriteMode::kTruncateOrCreate);
 
-  FileHandle handle;
+  internal::MakeScopedLockedFileHandleOptions options;
+  options.mode = mode;
+  options.permissions = FilePermissions::kOwnerOnly;
   if (log_open_error) {
-    handle = LoggingOpenFileForReadAndWrite(
-        file_path(), mode, FilePermissions::kOwnerOnly);
+    options.function_enum =
+        internal::FileOpenFunction::kLoggingOpenFileForReadAndWrite;
   } else {
-    handle = OpenFileForReadAndWrite(
-        file_path(), mode, FilePermissions::kOwnerOnly);
+    options.function_enum =
+        internal::FileOpenFunction::kOpenFileForReadAndWrite;
   }
 
   return MakeScopedLockedFileHandle(
-      handle, FileLocking::kExclusive, file_path());
+      options, FileLocking::kExclusive, file_path());
 }
 
 bool Settings::OpenAndReadSettings(Data* out_data) {

--- a/client/settings.h
+++ b/client/settings.h
@@ -37,6 +37,18 @@ struct ScopedLockedFileHandleTraits {
   static void Free(FileHandle handle);
 };
 
+enum class FileOpenFunction {
+  kLoggingOpenFileForRead,
+  kLoggingOpenFileForReadAndWrite,
+  kOpenFileForReadAndWrite,
+};
+
+struct MakeScopedLockedFileHandleOptions {
+  FileOpenFunction function_enum;
+  FileWriteMode mode;
+  FilePermissions permissions;
+};
+
 // TODO(mark): The timeout should be configurable by the client.
 #if BUILDFLAG(IS_IOS)
 // iOS background assertions only last 30 seconds, keep the timeout shorter.
@@ -54,6 +66,8 @@ constexpr double kUploadReportTimeoutSeconds = 60;
 //! should be retrieved via CrashReportDatabase::GetSettings().
 class Settings {
  public:
+  static inline constexpr char kLockfileExtension[] = ".__lock__";
+
   Settings();
 
   Settings(const Settings&) = delete;
@@ -128,6 +142,20 @@ class Settings {
   //!     error logged.
   bool SetLastUploadAttemptTime(time_t time);
 
+#if !CRASHPAD_FLOCK_ALWAYS_SUPPORTED
+  //! \brief Returns whether the lockfile for a file is expired.
+  //!
+  //! This could be part of ScopedLockedFileHandle, but this needs to be
+  //! public while ScopedLockedFileHandle is private to Settings.
+  //!
+  //! \param[in] file_path The path to the file whose lockfile will be checked.
+  //! \param[in] lockfile_ttl How long the lockfile has to live before expiring.
+  //!
+  //! \return `true` if the lock for the file is expired, otherwise `false`.
+  static bool IsLockExpired(const base::FilePath& file_path,
+                            time_t lockfile_ttl);
+#endif  // !CRASHPAD_FLOCK_ALWAYS_SUPPORTED
+
  private:
   struct Data;
 
@@ -135,7 +163,7 @@ class Settings {
   // and closes the file on destruction. Note that on Fuchsia, this handle DOES
   // NOT offer correct operation, only an attempt to DCHECK if racy behavior is
   // detected.
-#if BUILDFLAG(IS_FUCHSIA)
+#if !CRASHPAD_FLOCK_ALWAYS_SUPPORTED
   struct ScopedLockedFileHandle {
    public:
     ScopedLockedFileHandle();
@@ -187,11 +215,15 @@ class Settings {
 #else
   using ScopedLockedFileHandle =
       base::ScopedGeneric<FileHandle, internal::ScopedLockedFileHandleTraits>;
-#endif  // BUILDFLAG(IS_FUCHSIA)
+#endif  // !CRASHPAD_FLOCK_ALWAYS_SUPPORTED
   static ScopedLockedFileHandle MakeScopedLockedFileHandle(
-      FileHandle file,
+      const internal::MakeScopedLockedFileHandleOptions& options,
       FileLocking locking,
       const base::FilePath& file_path);
+
+  static FileHandle GetHandleFromOptions(
+      const base::FilePath& file_path,
+      const internal::MakeScopedLockedFileHandleOptions& options);
 
   // Opens the settings file for reading. On error, logs a message and returns
   // the invalid handle.

--- a/compat/linux/signal.h
+++ b/compat/linux/signal.h
@@ -22,6 +22,12 @@
 #define SS_AUTODISARM (1u << 31)
 #endif
 
+// Linux Kernel >= 5.11 flag for `sigaction::sa_flags`. Missing in headers from
+// earlier versions of Linux.
+#if !defined(SA_EXPOSE_TAGBITS)
+#define SA_EXPOSE_TAGBITS 0x00000800
+#endif
+
 // Missing from glibc and bionic-x86_64
 
 #if defined(__x86_64__) || defined(__i386__)

--- a/third_party/edo/BUILD.gn
+++ b/third_party/edo/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright 2018 The Chromium Authors.
+# Copyright 2018 The Chromium Authors
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/third_party/ninja/README.crashpad
+++ b/third_party/ninja/README.crashpad
@@ -1,0 +1,17 @@
+Name: ninja
+Short Name: ninja
+URL: https://github.com/ninja-build/ninja
+Revision: See the CIPD version in DEPS
+License: Apache License 2.0
+License File: https://github.com/ninja-build/ninja/blob/master/COPYING
+Security Critical: no
+
+Description:
+Ninja is a small build system with a focus on speed, and is used to build
+this project.
+
+The CIPD packages are built using the 3pp pipeline.
+https://chromium.googlesource.com/infra/infra/+/refs/heads/main/3pp/ninja/
+
+Local Modifications:
+None

--- a/third_party/ninja/ninja
+++ b/third_party/ninja/ninja
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+# Copyright 2022 Google Inc. All rights reserved
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -eu
+
+OS="$(uname -s)"
+THIS_DIR="$(dirname "${0}")"
+
+function print_help() {
+cat <<EOF >&2
+No ninja binary is available for this system.
+Try building your own binary by doing:
+  cd ~
+  git clone https://github.com/ninja-build/ninja.git
+  cd ninja && ./configure.py --bootstrap
+Then add ~/ninja/ to your PATH.
+EOF
+}
+
+case "${OS}" in
+  Linux)
+    exec "${THIS_DIR}/linux/ninja" "$@";;
+  Darwin)
+    ARCH="$(uname -m)"
+    case "${ARCH}" in
+      x86_64)
+        exec "${THIS_DIR}/mac-amd64/ninja" "$@";;
+      arm64)
+        exec "${THIS_DIR}/mac-arm64/ninja" "$@";;
+      *)
+        echo "Unsupported architecture ${ARCH}" >&2
+        print_help
+        exit 1;;
+    esac
+    ;;
+  *)
+    echo "Unsupported OS ${OS}" >&2
+    print_help
+    exit 1;;
+esac

--- a/third_party/ninja/ninja
+++ b/third_party/ninja/ninja
@@ -9,7 +9,7 @@ set -eu
 OS="$(uname -s)"
 THIS_DIR="$(dirname "${0}")"
 
-function print_help() {
+print_help() {
 cat <<EOF >&2
 No ninja binary is available for this system.
 Try building your own binary by doing:

--- a/util/BUILD.gn
+++ b/util/BUILD.gn
@@ -577,6 +577,8 @@ crashpad_static_library("util") {
     "$mini_chromium_source_parent:chromeos_buildflags",
   ]
 
+  configs = [ "../build:flock_always_supported_defines" ]
+
   if (crashpad_is_mac || crashpad_is_ios) {
     include_dirs += [ "$root_gen_dir" ]
     deps += [ ":mig_output" ]

--- a/util/file/file_io.h
+++ b/util/file/file_io.h
@@ -461,7 +461,7 @@ FileHandle LoggingOpenFileForReadAndWrite(const base::FilePath& path,
 // Fuchsia does not currently support any sort of file locking. See
 // https://crashpad.chromium.org/bug/196 and
 // https://crashpad.chromium.org/bug/217.
-#if !BUILDFLAG(IS_FUCHSIA)
+#if CRASHPAD_FLOCK_ALWAYS_SUPPORTED
 
 //! \brief Locks the given \a file using `flock()` on POSIX or `LockFileEx()` on
 //!     Windows.
@@ -500,7 +500,7 @@ FileLockingResult LoggingLockFile(FileHandle file,
 //! \return `true` on success, or `false` and a message will be logged.
 bool LoggingUnlockFile(FileHandle file);
 
-#endif  // !BUILDFLAG(IS_FUCHSIA)
+#endif  // CRASHPAD_FLOCK_ALWAYS_SUPPORTED
 
 //! \brief Wraps `lseek()` or `SetFilePointerEx()`. Logs an error if the
 //!     operation fails.

--- a/util/file/file_io_posix.cc
+++ b/util/file/file_io_posix.cc
@@ -208,7 +208,7 @@ FileHandle LoggingOpenFileForReadAndWrite(const base::FilePath& path,
   return fd;
 }
 
-#if !BUILDFLAG(IS_FUCHSIA)
+#if CRASHPAD_FLOCK_ALWAYS_SUPPORTED
 
 FileLockingResult LoggingLockFile(FileHandle file,
                                   FileLocking locking,
@@ -234,7 +234,7 @@ bool LoggingUnlockFile(FileHandle file) {
   return rv == 0;
 }
 
-#endif  // !BUILDFLAG(IS_FUCHSIA)
+#endif  // CRASHPAD_FLOCK_ALWAYS_SUPPORTED
 
 FileOffset LoggingSeekFile(FileHandle file, FileOffset offset, int whence) {
   off_t rv = lseek(file, offset, whence);

--- a/util/file/file_io_test.cc
+++ b/util/file/file_io_test.cc
@@ -546,7 +546,9 @@ TEST(FileIO, FileShareMode_Write_Write) {
 // Fuchsia does not currently support any sort of file locking. See
 // https://crashpad.chromium.org/bug/196 and
 // https://crashpad.chromium.org/bug/217.
-#if !BUILDFLAG(IS_FUCHSIA)
+// Android can conditionally not support file locking depending on what type of
+// filesystem is being used to store settings.dat.
+#if CRASHPAD_FLOCK_ALWAYS_SUPPORTED
 
 TEST(FileIO, MultipleSharedLocks) {
   ScopedTempDir temp_dir;
@@ -721,7 +723,7 @@ TEST(FileIO, ExclusiveVsExclusivesNonBlocking) {
   EXPECT_TRUE(LoggingUnlockFile(handle2.get()));
 }
 
-#endif  // !BUILDFLAG(IS_FUCHSIA)
+#endif  // CRASHPAD_FLOCK_ALWAYS_SUPPORTED
 
 TEST(FileIO, FileSizeByHandle) {
   EXPECT_EQ(LoggingFileSizeByHandle(kInvalidFileHandle), -1);

--- a/util/linux/ptrace_client.cc
+++ b/util/linux/ptrace_client.cc
@@ -331,6 +331,11 @@ ssize_t PtraceClient::ReadUpTo(VMAddress address, size_t size, void* buffer) {
       return total_read;
     }
 
+    if (static_cast<size_t>(bytes_read) > size) {
+      LOG(ERROR) << "invalid size " << bytes_read;
+      return -1;
+    }
+
     if (!LoggingReadFileExactly(sock_, buffer_c, bytes_read)) {
       return -1;
     }

--- a/util/net/http_transport_libcurl.cc
+++ b/util/net/http_transport_libcurl.cc
@@ -522,6 +522,10 @@ size_t HTTPTransportLibcurl::WriteResponseBody(char* buffer,
                                                size_t size,
                                                size_t nitems,
                                                void* userdata) {
+#if defined(MEMORY_SANITIZER)
+  // Work around an MSAN false-positive in passing `userdata`.
+  __msan_unpoison(&userdata, sizeof(userdata));
+#endif
   std::string* response_body = reinterpret_cast<std::string*>(userdata);
 
   // This libcurl callback mimics the silly stdio-style fread() interface: size


### PR DESCRIPTION
@Swatinem, again mostly cosmetic changes for our use-case, but noteworthy:

- on Linux >= 5.11 aarch64 TBI and MTE nibbles are exposed in signal-handlers: https://chromium-review.googlesource.com/c/crashpad/crashpad/+/4024204
- similiar to breakpad, "recent" glibc updates required changes to code referencing `MINSIGSTKSZ` as a constant: https://chromium-review.googlesource.com/c/crashpad/crashpad/+/4020320
- it also seems that crashpad is transitioning to ninja (we can ignore this at this point, IMO)