### PR TITLE
fix: remove find_package(OpenSSL)  for Linux builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,14 +25,6 @@ if(CRASHPAD_ZLIB_SYSTEM)
     find_package(ZLIB REQUIRED)
 endif()
 
-
-if(LINUX OR ANDROID)
-    find_package(OpenSSL)
-    if(OPENSSL_FOUND)
-        set(CRASHPAD_USE_BORINGSSL ON)
-    endif()
-endif()
-
 if (NOT (ANDROID OR FUCHSIA))
     add_compile_definitions(CRASHPAD_FLOCK_ALWAYS_SUPPORTED=1)
 else()

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -267,6 +267,10 @@ if(LINUX OR ANDROID)
 
         SET(HTTP_TRANSPORT_IMPL net/http_transport_libcurl.cc)
     else()
+        find_package(OpenSSL)
+        if(OPENSSL_FOUND)
+            set(CRASHPAD_USE_BORINGSSL ON)
+        endif()
         SET(HTTP_TRANSPORT_IMPL net/http_transport_socket.cc)
     endif()
     


### PR DESCRIPTION
Since we no longer use `http_transport_socket` on Linux, there is no need to depend on `OpenSSL` directly anymore. We use whatever the present `libcurl` implementation uses as its TLS implementation.

I also moved the dependency discovery for Android (which we currently do not use) to `crashpad-util` to isolate it.

Indirectly raised here: https://github.com/getsentry/sentry-native/issues/370 and https://github.com/getsentry/sentry-native/discussions/808