### PR TITLE
Fix compiler error with msvc on non-unicode system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,9 @@ if(WIN32)
     )
 endif()
 if(MSVC)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /utf-8")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /utf-8")
+
     string(REGEX REPLACE "/[Ww][0123]" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
     string(REGEX REPLACE "/[Ww][0123]" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     target_compile_options(crashpad_interface INTERFACE


### PR DESCRIPTION
On non-unicode system, msvc treat utf-8 file without bom as ANSI encode, which cause compiler warning C481.
`/utf-8` force msvc compiler treat file as utf-8 encode.

relative issue: https://github.com/getsentry/sentry-native/issues/443