### PR TITLE
crashpad_handler: add response body to error log if status is not OK

### DIFF
--- a/util/net/http_transport_libcurl.cc
+++ b/util/net/http_transport_libcurl.cc
@@ -483,7 +483,8 @@ bool HTTPTransportLibcurl::ExecuteSynchronously(std::string* response_body) {
   }
 
   if (status != 200) {
-    LOG(ERROR) << base::StringPrintf("HTTP status %ld", status);
+    LOG(ERROR) << base::StringPrintf(
+        "HTTP status %ld, response = \"%s\"", status, response_body->c_str());
     return false;
   }
 


### PR DESCRIPTION
This is important because if the `crashpad_handler` receives a 400 (`Bad Request`) for whichever reason from `relay`, it will detail why in the response body. This helps identify the cause of the rejection.

I am open to suggestions for further logs if you have any, but I think this covers the most immediate needs. Everything else would require access to the minidump or envelope, right?