### PR TITLE
build: adjust for Windows ARM64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,11 @@ function(crashpad_install_dev)
 endfunction()
 
 if(WIN32)
-    enable_language(ASM_MASM)
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES ARM64)
+        enable_language(ASM_MARMASM)
+    else()
+        enable_language(ASM_MASM)
+    endif()
 
     if(MINGW)
         find_program(JWASM_FOUND jwasm)


### PR DESCRIPTION
Windows ARM64 uses a different ASM variant.  The assembly is already correct but the CMake setup for the variant was not.  This corrects that to enable building crashpad for Windows ARM64.  Beyond this change, an update to zlib is required.