### PR TITLE
build: remove obsolete source file

### DIFF
--- a/third_party/zlib/CMakeLists.txt
+++ b/third_party/zlib/CMakeLists.txt
@@ -50,8 +50,6 @@ else()
         if(NOT MSVC)
             target_compile_options(crashpad_zlib PRIVATE -msse4.2 -mpclmul)
         endif()
-    else()
-        target_sources(crashpad_zlib PRIVATE zlib/simd_stub.c)
     endif()
     target_compile_definitions(crashpad_zlib PUBLIC
         CRASHPAD_ZLIB_SOURCE_EMBEDDED


### PR DESCRIPTION
`simd_stub.c` was removed from the repository upstream. This updates the CMakeLists.txt so that it is possible to build for Windows ARM64 (and AMD64).