### PR TITLE
build: adjust process name matching

### DIFF
--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -385,7 +385,7 @@ if(WIN32)
         win/traits.h
         win/xp_compat.h
     )
-    if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+    if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm|ARM64")
         target_sources(crashpad_util PRIVATE
             misc/capture_context_win_arm64.asm
         )


### PR DESCRIPTION
The ARM64 build should use the ARM64 branch.  The normal spelling for the CMAKE_SYSTEM_PROCESSOR is ARM64 when building with MSVC toolsets.  This allows building for Windows ARM64 with MSBuild + CMake.