### PR TITLE
FirstChanceHandler execute once

### DIFF
--- a/client/crashpad_client_win.cc
+++ b/client/crashpad_client_win.cc
@@ -155,10 +155,6 @@ LONG WINAPI UnhandledExceptionHandler(EXCEPTION_POINTERS* exception_pointers) {
     return EXCEPTION_CONTINUE_SEARCH;
   }
 
-  if (first_chance_handler_ && first_chance_handler_(exception_pointers)) {
-    return EXCEPTION_CONTINUE_SEARCH;
-  }
-
   // Otherwise, we know the handler startup has succeeded, and we can continue.
 
   // Tracks whether a thread has already entered UnhandledExceptionHandler.
@@ -178,6 +174,10 @@ LONG WINAPI UnhandledExceptionHandler(EXCEPTION_POINTERS* exception_pointers) {
   // that's blocked at this location.
   if (base::subtle::Barrier_AtomicIncrement(&have_crashed, 1) > 1) {
     SleepEx(INFINITE, false);
+  }
+
+  if (first_chance_handler_ && first_chance_handler_(exception_pointers)) {
+    SafeTerminateProcess(GetCurrentProcess(), kTerminationCodeCrashNoDump);
   }
 
   // Otherwise, we're the first thread, so record the exception pointer and


### PR DESCRIPTION
For platfroms that support FirstChanceHandler (windows, linux) execute it only once.

For windows that mimics behaviour of `sentry__crashpad_handler` but avoid an issue with a possible race condition for multiple executions of `sentry__crashpad_handler`:
- event creation on for a path `crashpad_state_t::event_path` during  `crashpad_backend_flush_scope`
- `crashpad_state_t::event` inside `sentry__crashpad_handler`

That would also remove necessety of having `sentry__enter_signal_handler` for linux, because crashpad has same logic inside `SignalHandler::HandleOrReraiseSignal`.