### PR TITLE
update build-script for transport-compression changes in sentry-native

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ else()
 endif()
 option(CRASHPAD_ZLIB_SYSTEM "Use system zlib library" "${CRASHPAD_ZLIB_SYSTEM_DEFAULT}")
 
-if(CRASHPAD_ZLIB_SYSTEM)
+if(CRASHPAD_ZLIB_SYSTEM AND NOT ZLIB_FOUND)
     find_package(ZLIB REQUIRED)
 endif()
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -253,18 +253,7 @@ if(LINUX OR ANDROID)
             find_package(CURL REQUIRED)
         endif()
 
-        if(TARGET CURL::libcurl) # Only available in cmake 3.12+
-            target_link_libraries(crashpad_util PRIVATE CURL::libcurl)
-        else()
-            # Needed for cmake < 3.12 support (cmake 3.12 introduced the target CURL::libcurl)
-            target_include_directories(crashpad_util PRIVATE ${CURL_INCLUDE_DIR})
-            # The exported sentry target must not contain any path of the build machine, therefore use generator expressions
-            string(REPLACE ";" "$<SEMICOLON>" GENEX_CURL_LIBRARIES "${CURL_LIBRARIES}")
-            string(REPLACE ";" "$<SEMICOLON>" GENEX_CURL_COMPILE_DEFINITIONS "${CURL_COMPILE_DEFINITIONS}")
-            target_link_libraries(crashpad_util PRIVATE $<BUILD_INTERFACE:${GENEX_CURL_LIBRARIES}>)
-            target_compile_definitions(crashpad_util PRIVATE $<BUILD_INTERFACE:${GENEX_CURL_COMPILE_DEFINITIONS}>)
-        endif()
-
+        target_link_libraries(crashpad_util PRIVATE CURL::libcurl)
         SET(HTTP_TRANSPORT_IMPL net/http_transport_libcurl.cc)
     else()
         find_package(OpenSSL)


### PR DESCRIPTION
Invoke `find_package()` only if `zlib` wasn't found in the parent (related: https://github.com/getsentry/sentry-native/pull/954).

Also got rid of `CMake < 3.12` noise.