### PR TITLE
Support Epic's "Easy Anti Cheat"

### DIFF
--- a/client/crashpad_client_win.cc
+++ b/client/crashpad_client_win.cc
@@ -438,7 +438,7 @@ bool StartHandlerProcess(
   }
 
   ScopedKernelHANDLE this_process(
-      OpenProcess(kXPProcessAllAccess, true, GetCurrentProcessId()));
+      OpenProcess(kXPProcessLimitedAccess, true, GetCurrentProcessId()));
   if (!this_process.is_valid()) {
     PLOG(ERROR) << "OpenProcess";
     return false;

--- a/util/win/xp_compat.h
+++ b/util/win/xp_compat.h
@@ -26,6 +26,10 @@ enum {
   //! against a Vista+ SDK results in `ERROR_ACCESS_DENIED` when running on XP.
   //! See https://msdn.microsoft.com/library/ms684880.aspx.
   kXPProcessAllAccess = STANDARD_RIGHTS_REQUIRED | SYNCHRONIZE | 0xFFF,
+  
+  //  A limited access version, suitable for initial access to the process.
+  kXPProcessLimitedAccess = PROCESS_DUP_HANDLE | PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_TERMINATE | SYNCHRONIZE,
+ 
 
   //! \brief This is the XP-suitable value of `THREAD_ALL_ACCESS`.
   //!


### PR DESCRIPTION
See issue #975

Two changes are made, for the Windows platform:

- The target process is opened with _limited_ permissions, and only upgraded to full permission when required.  When an anti-cheat watchdog is present, the target process is often protected until it crashes.
- The target thread may be already suspended by the watchdog process.  Accept a failure to suspend the target thread.
