### PR TITLE
Support building with clang-cl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,9 @@ jobs:
             CXX: clang++
           - name: Windows (x64)
             platform: windows-latest
+          - name: Windows ClangCL (x64)
+            platform: windows-latest
+            CMAKE_DEFINES: -G Visual Studio 17 2022 -A x64 -T ClangCL
           - name: Windows (arm64)
             platform: windows-latest
             CMAKE_DEFINES: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/win_arm64.cmake -A arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           [ "${{ matrix.CC }}" ] && export CC="${{ matrix.CC }}"
           [ "${{ matrix.CXX }}" ] && export CXX="${{ matrix.CXX }}"
           echo "CMAKE_DEFINES=${CMAKE_DEFINES}"
-          cmake -B cmake-build -D CRASHPAD_BUILD_TOOLS=On ${CMAKE_DEFINES}
+          cmake -B cmake-build -D CRASHPAD_BUILD_TOOLS=On "${CMAKE_DEFINES}"
           cmake --build cmake-build --parallel
 
       - name: Build crashpad with client-side stack traces
@@ -91,7 +91,7 @@ jobs:
           [ "${{ matrix.CC }}" ] && export CC="${{ matrix.CC }}"
           [ "${{ matrix.CXX }}" ] && export CXX="${{ matrix.CXX }}"
           echo "CMAKE_DEFINES=${CMAKE_DEFINES}"
-          cmake -B cmake-build-stacks -D CRASHPAD_ENABLE_STACKTRACE=ON ${CMAKE_DEFINES}
+          cmake -B cmake-build-stacks -D CRASHPAD_ENABLE_STACKTRACE=ON "${CMAKE_DEFINES}"
           cmake --build cmake-build-stacks --parallel
 
   build-ios:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
             platform: windows-latest
           - name: Windows ClangCL (x64)
             platform: windows-latest
-            CMAKE_DEFINES: -G "Visual Studio 17 2022" -A x64 -T ClangCL
+            CMAKE_DEFINES: -G 'Visual Studio 17 2022' -A x64 -T ClangCL
           - name: Windows (arm64)
             platform: windows-latest
             CMAKE_DEFINES: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/win_arm64.cmake -A arm64
@@ -44,7 +44,7 @@ jobs:
             platform: windows-latest
             MINGW: 1
             MINGW_PKG_PREFIX: x86_64-w64-mingw32
-            MINGW_ASM_MASM_COMPILER: llvm-ml;-m64
+            MINGW_ASM_MASM_COMPILER: "'llvm-ml;-m64'"
             CMAKE_DEFINES: -DCRASHPAD_ZLIB_SYSTEM=OFF -DCRASHPAD_BUILD_TOOLS=OFF -G Ninja
           - name: LLVM-MINGW (arm64)
             platform: windows-latest
@@ -56,7 +56,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.platform }}
     env:
-      CMAKE_DEFINES: ${{ matrix.CMAKE_DEFINES }}
+      CMAKE_DEFINES: "${{ matrix.CMAKE_DEFINES }}"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           [ "${{ matrix.CC }}" ] && export CC="${{ matrix.CC }}"
           [ "${{ matrix.CXX }}" ] && export CXX="${{ matrix.CXX }}"
           echo "CMAKE_DEFINES=${CMAKE_DEFINES}"
-          cmake -B cmake-build -D CRASHPAD_BUILD_TOOLS=On ${CMAKE_DEFINES}
+          eval "cmake -B cmake-build -D CRASHPAD_BUILD_TOOLS=On $CMAKE_DEFINES"
           cmake --build cmake-build --parallel
 
       - name: Build crashpad with client-side stack traces
@@ -91,7 +91,7 @@ jobs:
           [ "${{ matrix.CC }}" ] && export CC="${{ matrix.CC }}"
           [ "${{ matrix.CXX }}" ] && export CXX="${{ matrix.CXX }}"
           echo "CMAKE_DEFINES=${CMAKE_DEFINES}"
-          cmake -B cmake-build-stacks -D CRASHPAD_ENABLE_STACKTRACE=ON ${CMAKE_DEFINES}
+          eval "cmake -B cmake-build-stacks -D CRASHPAD_ENABLE_STACKTRACE=ON $CMAKE_DEFINES"
           cmake --build cmake-build-stacks --parallel
 
   build-ios:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
             platform: windows-latest
           - name: Windows ClangCL (x64)
             platform: windows-latest
-            CMAKE_DEFINES: -G Visual Studio 17 2022 -A x64 -T ClangCL
+            CMAKE_DEFINES: -G "Visual Studio 17 2022" -A x64 -T ClangCL
           - name: Windows (arm64)
             platform: windows-latest
             CMAKE_DEFINES: -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/win_arm64.cmake -A arm64
@@ -82,7 +82,7 @@ jobs:
           [ "${{ matrix.CC }}" ] && export CC="${{ matrix.CC }}"
           [ "${{ matrix.CXX }}" ] && export CXX="${{ matrix.CXX }}"
           echo "CMAKE_DEFINES=${CMAKE_DEFINES}"
-          cmake -B cmake-build -D CRASHPAD_BUILD_TOOLS=On "${CMAKE_DEFINES}"
+          cmake -B cmake-build -D CRASHPAD_BUILD_TOOLS=On ${CMAKE_DEFINES}
           cmake --build cmake-build --parallel
 
       - name: Build crashpad with client-side stack traces
@@ -91,7 +91,7 @@ jobs:
           [ "${{ matrix.CC }}" ] && export CC="${{ matrix.CC }}"
           [ "${{ matrix.CXX }}" ] && export CXX="${{ matrix.CXX }}"
           echo "CMAKE_DEFINES=${CMAKE_DEFINES}"
-          cmake -B cmake-build-stacks -D CRASHPAD_ENABLE_STACKTRACE=ON "${CMAKE_DEFINES}"
+          cmake -B cmake-build-stacks -D CRASHPAD_ENABLE_STACKTRACE=ON ${CMAKE_DEFINES}
           cmake --build cmake-build-stacks --parallel
 
   build-ios:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,8 @@ if(MSVC)
         $<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<C_COMPILER_ID:Clang>>:-Wno-microsoft-cast> # implicit conversion between pointer-to-function and pointer-to-object
         $<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<C_COMPILER_ID:Clang>>:-Wno-unused-parameter> # same as /wd4100
         $<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<C_COMPILER_ID:Clang>>:-Wno-deprecated-declarations> # same as /wd4996
+        $<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<C_COMPILER_ID:Clang>>:-Wno-format> # only Clang-CL
+        $<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<C_COMPILER_ID:Clang>>:-Wno-cast-function-type-mismatch> # only Clang-CL
     )
 elseif(MINGW)
     # redirect to wmain

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,15 +122,12 @@ if(MSVC)
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4351> # New behavior: elements of array will be default initialized.
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4577> # 'noexcept' used with no exception handling mode specified.
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4996> # 'X' was declared deprecated.
+        $<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<C_COMPILER_ID:Clang>>:-Wno-missing-field-initializers> # missing field initializer
+        $<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<C_COMPILER_ID:Clang>>:-Wno-sign-compare> # comparison of integers of different signs
+        $<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<C_COMPILER_ID:Clang>>:-Wno-microsoft-cast> # implicit conversion between pointer-to-function and pointer-to-object
+        $<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<C_COMPILER_ID:Clang>>:-Wno-unused-parameter> # same as /wd4100
+        $<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<C_COMPILER_ID:Clang>>:-Wno-deprecated-declarations> # same as /wd4996
     )
-
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang") # clang-cl
-        target_compile_options(crashpad_interface INTERFACE
-            $<$<COMPILE_LANGUAGE:C,CXX>:-Wno-missing-field-initializers> # missing field initializer
-            $<$<COMPILE_LANGUAGE:C,CXX>:-Wno-sign-compare> # comparison of integers of different signs
-            $<$<COMPILE_LANGUAGE:C,CXX>:-Wno-microsoft-cast> # implicit conversion between pointer-to-function and pointer-to-object
-        )
-    endif()
 
 elseif(MINGW)
     # redirect to wmain

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,15 @@ if(MSVC)
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4577> # 'noexcept' used with no exception handling mode specified.
         $<$<COMPILE_LANGUAGE:C,CXX>:/wd4996> # 'X' was declared deprecated.
     )
+
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang") # clang-cl
+        target_compile_options(crashpad_interface INTERFACE
+            $<$<COMPILE_LANGUAGE:C,CXX>:-Wno-missing-field-initializers> # missing field initializer
+            $<$<COMPILE_LANGUAGE:C,CXX>:-Wno-sign-compare> # comparison of integers of different signs
+            $<$<COMPILE_LANGUAGE:C,CXX>:-Wno-microsoft-cast> # implicit conversion between pointer-to-function and pointer-to-object
+        )
+    endif()
+
 elseif(MINGW)
     # redirect to wmain
     # FIXME: cmake 3.13 added target_link_options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,6 @@ if(MSVC)
         $<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<C_COMPILER_ID:Clang>>:-Wno-unused-parameter> # same as /wd4100
         $<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<C_COMPILER_ID:Clang>>:-Wno-deprecated-declarations> # same as /wd4996
     )
-
 elseif(MINGW)
     # redirect to wmain
     # FIXME: cmake 3.13 added target_link_options

--- a/util/file/filesystem.h
+++ b/util/file/filesystem.h
@@ -19,6 +19,7 @@
 
 #include "base/files/file_path.h"
 #include "util/file/file_io.h"
+#include <cstdint>
 
 namespace crashpad {
 


### PR DESCRIPTION
This PR adds support for building crashpad with `clang-cl` (see https://github.com/getsentry/sentry-native/issues/689). It adds the following flags to `crashpad_interface`:

- `-Wno-missing-field-initializers` (e.g. required in [util/file/file_io_win.cc](https://github.com/getsentry/crashpad/blob/96e301b7d6b81990a244d7de41a0d36eeb60899e/util/file/file_io_win.cc#L197))
- `-Wno-sign-compare` (e.g. required in third_party/mini_chromium/mini_chromium/base/threading/thread_local_storage.h)
- `-Wno-microsoft-cast` (e.g. required in [client/crashpad_client_win.cc](https://github.com/getsentry/crashpad/blob/96e301b7d6b81990a244d7de41a0d36eeb60899e/client/crashpad_client_win.cc#L728))

Crashpad itself (or rather mini_chromium) doesn't appear to support `clang-cl` and [defaults to `cl` on Windows](https://chromium.googlesource.com/chromium/mini_chromium/+/56d78c09f249abe33104c668f59000ef3f883bb4/build/config/BUILD.gn#637) (though I don't know gn that well).