### PR TITLE
[crashpad] Add compilation condition restrictions to fix sentry-native linux runtime error

### DIFF
--- a/handler/CMakeLists.txt
+++ b/handler/CMakeLists.txt
@@ -89,7 +89,7 @@ if(NOT IOS)
         main.cc
     )
 
-    if(LINUX)
+    if(LINUX AND BUILD_SHARED_LIBS)
         target_sources(crashpad_handler PRIVATE
             ../client/pthread_create_linux.cc
         )


### PR DESCRIPTION
When install sentry-native:x64-linux in vcpkg, the cmake project generation & building it works fine, however while trying to run the app with dummy crash (assigning a nullptr after initialization of sentry) the crash raport doesn't gets send to the sentry backend.
````
[1717:1717:20240604,064748.491454:FATAL pthread_create_linux.cc:54] Check failed: next_pthread_create. dlsym: RTLD_NEXT used in code not dynamically loaded
````
Add constraint to compile pthread_create_linux.cc only when BUILD_SHARED_LIBS to fix error。
Related issue:https://github.com/getsentry/sentry-native/issues/596 
https://github.com/microsoft/vcpkg/issues/39114
