### PR TITLE
fix: replace find_package() with find_dependency() in CMake config

### DIFF
--- a/crashpad-config.cmake.in
+++ b/crashpad-config.cmake.in
@@ -1,7 +1,9 @@
 include("${CMAKE_CURRENT_LIST_DIR}/crashpad-targets.cmake")
 
+include(CMakeFindDependencyMacro)
+
 if(@CRASHPAD_ZLIB_SYSTEM@)
-    find_package(ZLIB REQUIRED)
+    find_dependency(ZLIB REQUIRED)
     target_include_directories(crashpad::zlib INTERFACE ${ZLIB_INCLUDE_DIRS})
     target_compile_definitions(crashpad::zlib INTERFACE ${ZLIB_COMPILE_DEFINITIONS})
     target_link_libraries(crashpad::zlib INTERFACE ${ZLIB_LIBRARIES})


### PR DESCRIPTION
analog to the changes here: https://github.com/getsentry/sentry-native/pull/1007/files#diff-782c438ad792c360444cd19d38cae99dd1e21a9116c373f2d9f4e94a3df7304f