### PR TITLE
fix: further dependency use/export cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ else()
 endif()
 option(CRASHPAD_ZLIB_SYSTEM "Use system zlib library" "${CRASHPAD_ZLIB_SYSTEM_DEFAULT}")
 
-if(CRASHPAD_ZLIB_SYSTEM AND NOT ZLIB_FOUND)
+if(CRASHPAD_ZLIB_SYSTEM AND NOT TARGET ZLIB::ZLIB)
     find_package(ZLIB REQUIRED)
 endif()
 

--- a/crashpad-config.cmake.in
+++ b/crashpad-config.cmake.in
@@ -1,12 +1,11 @@
-include("${CMAKE_CURRENT_LIST_DIR}/crashpad-targets.cmake")
-
-include(CMakeFindDependencyMacro)
-
 if(@CRASHPAD_ZLIB_SYSTEM@)
-    find_dependency(ZLIB REQUIRED)
+    include(CMakeFindDependencyMacro)
+    find_dependency(ZLIB)
     target_include_directories(crashpad::zlib INTERFACE ${ZLIB_INCLUDE_DIRS})
     target_compile_definitions(crashpad::zlib INTERFACE ${ZLIB_COMPILE_DEFINITIONS})
     target_link_libraries(crashpad::zlib INTERFACE ${ZLIB_LIBRARIES})
 endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/crashpad-targets.cmake")
 
 @PACKAGE_INIT@

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -249,7 +249,7 @@ endif()
 
 if(LINUX OR ANDROID)
     if (LINUX)
-        if(NOT CURL_FOUND) # Some other lib might bring libcurl already
+        if(NOT TARGET CURL::libcurl) # Some other lib might bring libcurl already
             find_package(CURL REQUIRED)
         endif()
 


### PR DESCRIPTION
* Replace checks for `_FOUND` variables with checks to actual targets before we `find_package()`  in our build scripts.
* Ensure that we include the crashpad targets in the export configuration after all invocations of `find_dependency()`
* Remove `REQUIRED` from the  `find_dependency()` invocations and let it retrieve the value from the `find_package()` invocations in the build scripts.