### PR TITLE
fix: new ci runner image breakage

### DIFF
--- a/third_party/mini_chromium/CMakeLists.txt
+++ b/third_party/mini_chromium/CMakeLists.txt
@@ -146,7 +146,10 @@ else()
 endif()
 
 if(APPLE)
-    target_compile_options(mini_chromium PUBLIC -fobjc-arc -fno-objc-arc-exceptions)
+    target_compile_options(mini_chromium
+        PUBLIC "-fobjc-arc" "-fno-objc-arc-exceptions"
+        PRIVATE "-Wno-deprecated-declarations"
+    )
 endif()
 if(APPLE AND NOT IOS)
     target_link_libraries(mini_chromium PUBLIC

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -507,6 +507,8 @@ if(APPLE)
             "-framework UIKit"
         )
     endif()
+
+    target_compile_options(crashpad_util PRIVATE "-Wno-deprecated-declarations")
 endif()
 
 if(LINUX)


### PR DESCRIPTION
The following PRs experienced macOs-11 image brownouts:
https://github.com/getsentry/sentry-native/pull/1013
https://github.com/getsentry/sentry-native/pull/1014

So, it is time to upgrade and fix the compiler breakage.

This will be tracked and merged via https://github.com/getsentry/sentry-native/pull/1014.
