### PR TITLE
feat: windows binary versioning

### DIFF
--- a/handler/CMakeLists.txt
+++ b/handler/CMakeLists.txt
@@ -113,6 +113,10 @@ if(NOT IOS)
         if(MSVC)
             target_link_options(crashpad_handler PRIVATE "/SUBSYSTEM:WINDOWS")
         endif()
+
+        if (COMMAND sentry_add_version_resource)
+            sentry_add_version_resource(crashpad_handler "Crashpad Handler")
+        endif()
     endif()
 
     set_property(TARGET crashpad_handler PROPERTY EXPORT_NAME crashpad_handler)
@@ -143,6 +147,10 @@ if (WIN32)
     set_property(TARGET crashpad_wer PROPERTY EXPORT_NAME crashpad_wer)
     set_property(TARGET crashpad_wer PROPERTY PREFIX "") # ensure MINGW doesn't prefix "lib" to dll name
     add_library(crashpad::wer ALIAS crashpad_wer)
+
+    if (COMMAND sentry_add_version_resource)
+        sentry_add_version_resource(crashpad_wer "Crashpad WER Module")
+    endif()
 
     install(TARGETS crashpad_wer EXPORT crashpad_export
         RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"


### PR DESCRIPTION
This adds binary versioning of `crashpad_handler.exe` and `crashpad_wer.dll`. It depends on `sentry-native` as the parent project. If it doesn't exist, no version information is added.

I am adding this to https://github.com/getsentry/sentry-native/pull/1076 because it could be convenient to check if the respective binaries come from the same release as the Native SDK client library when using the `crashpad` backend.