### PR TITLE
fix: proxy-upload semaphore_wait timeout

### DIFF
--- a/util/net/http_transport_mac.mm
+++ b/util/net/http_transport_mac.mm
@@ -294,50 +294,62 @@ bool HTTPTransportMac::ExecuteProxyRequest(NSMutableURLRequest* request,
     NSURLSession* session =
         [NSURLSession sessionWithConfiguration:sessionConfig];
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-    [[session dataTaskWithRequest:request
-                completionHandler:^(
-                    NSData* body, NSURLResponse* response, NSError* error) {
-                  if (error) {
-                    Metrics::CrashUploadErrorCode(error.code);
-                    LOG(ERROR) << [[error localizedDescription] UTF8String]
-                               << " (" << [[error domain] UTF8String] << " "
-                               << [error code] << ")";
-                    sync_rv = false;
-                    dispatch_semaphore_signal(semaphore);
-                    return;
-                  }
-                  if (!response) {
-                    LOG(ERROR) << "no response";
-                    sync_rv = false;
-                    dispatch_semaphore_signal(semaphore);
-                    return;
-                  }
-                  auto http_response =
-                      base::apple::ObjCCast<NSHTTPURLResponse>(response);
-                  if (!http_response) {
-                    LOG(ERROR) << "no http_response";
-                    sync_rv = false;
-                    dispatch_semaphore_signal(semaphore);
-                    return;
-                  }
-                  NSInteger http_status = [http_response statusCode];
-                  if (http_status < 200 || http_status > 203) {
-                    LOG(ERROR) << base::StringPrintf(
-                        "HTTP status %ld", implicit_cast<long>(http_status));
-                    sync_rv = false;
-                    dispatch_semaphore_signal(semaphore);
-                    return;
-                  }
+    NSURLSessionDataTask* task = [session
+        dataTaskWithRequest:request
+          completionHandler:^(
+              NSData* body, NSURLResponse* response, NSError* error) {
+            if (error) {
+              Metrics::CrashUploadErrorCode(error.code);
+              LOG(ERROR) << [[error localizedDescription] UTF8String] << " (" <<
+                  [[error domain] UTF8String] << " " << [error code] << ")";
+              sync_rv = false;
+              dispatch_semaphore_signal(semaphore);
+              return;
+            }
+            if (!response) {
+              LOG(ERROR) << "no response";
+              sync_rv = false;
+              dispatch_semaphore_signal(semaphore);
+              return;
+            }
+            auto http_response =
+                base::apple::ObjCCast<NSHTTPURLResponse>(response);
+            if (!http_response) {
+              LOG(ERROR) << "no http_response";
+              sync_rv = false;
+              dispatch_semaphore_signal(semaphore);
+              return;
+            }
+            NSInteger http_status = [http_response statusCode];
+            if (http_status < 200 || http_status > 203) {
+              LOG(ERROR) << base::StringPrintf(
+                  "HTTP status %ld", implicit_cast<long>(http_status));
+              sync_rv = false;
+              dispatch_semaphore_signal(semaphore);
+              return;
+            }
 
-                  if (response_body) {
-                    response_body->assign(
-                        static_cast<const char*>([body bytes]), [body length]);
-                  }
-                  sync_rv = true;
-                  dispatch_semaphore_signal(semaphore);
-                }] resume];
+            if (response_body) {
+              response_body->assign(static_cast<const char*>([body bytes]),
+                                    [body length]);
+            }
+            sync_rv = true;
+            dispatch_semaphore_signal(semaphore);
+          }];
 
-    dispatch_semaphore_wait(semaphore, (dispatch_time_t)(10 * NSEC_PER_SEC));
+    if (task == nil) {
+      LOG(ERROR) << "Failed to create upload task.";
+      return false;
+    }
+
+    [task resume];
+
+    if (0 !=
+        dispatch_semaphore_wait(
+            semaphore, dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC))) {
+      LOG(ERROR) << "Upload task semaphore wait timed out";
+      sync_rv = false;
+    }
   }
   return sync_rv;
 }


### PR DESCRIPTION
While testing the `crashpad_handler` HTTP-proxy-based report upload on macOS without a registered `mitmproxy` certificate, I saw that we don't get any error logs from the `crashpad_handler` and never get into the completion handler.

This was a bug: I incorrectly specified the `dispatch_semaphore_wait()` timeout. The timeout it accepts is not a relative offset but an absolute timeout! So, by passing a 10-second offset, the timeout expects 10 seconds after an arbitrary absolute start point (which almost assuredly already passed). 

I am still trying to understand why this wasn't an issue when testing the initial implementation, which I had to do so many times due to the finicky proxy config of `NSURLSession`.
