### PR TITLE
feat: crashpad cxx17 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "third_party/mini_chromium/mini_chromium"]
 	path = third_party/mini_chromium/mini_chromium
-	url = https://chromium.googlesource.com/chromium/mini_chromium
+	url = https://github.com/supervacuus/mini_chromium_cxx17.git
 [submodule "third_party/zlib/zlib"]
 	path = third_party/zlib/zlib
 	url = https://chromium.googlesource.com/chromium/src/third_party/zlib

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "third_party/mini_chromium/mini_chromium"]
 	path = third_party/mini_chromium/mini_chromium
-	url = https://github.com/supervacuus/mini_chromium_cxx17.git
+	url = https://github.com/getsentry/mini_chromium.git
 [submodule "third_party/zlib/zlib"]
 	path = third_party/zlib/zlib
 	url = https://chromium.googlesource.com/chromium/src/third_party/zlib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ else()
     enable_language(ASM)
 endif()
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_library(crashpad_interface INTERFACE)

--- a/util/misc/uuid.cc
+++ b/util/misc/uuid.cc
@@ -64,8 +64,13 @@ void UUID::InitializeFromBytes(const uint8_t* bytes_ptr) {
   data_1 = base::numerics::U32FromBigEndian(bytes.subspan<0u, 4u>());
   data_2 = base::numerics::U16FromBigEndian(bytes.subspan<4u, 2u>());
   data_3 = base::numerics::U16FromBigEndian(bytes.subspan<6u, 2u>());
+#if defined(__cpp_lib_ranges) && __cpp_lib_ranges >= 201911L
   std::ranges::copy(bytes.subspan<8u, 2u>(), data_4);
   std::ranges::copy(bytes.subspan<10u, 6u>(), data_5);
+#else
+  memcpy(data_4, bytes.data() + 8u, 2u);
+  memcpy(data_5, bytes.data() + 10u, 6u);
+#endif
 }
 
 bool UUID::InitializeFromString(const base::StringPiece& string) {

--- a/util/misc/uuid.cc
+++ b/util/misc/uuid.cc
@@ -121,7 +121,7 @@ bool UUID::InitializeWithNew() {
   // from libuuid is not available everywhere.
   // On Windows, do not use UuidCreate() to avoid a dependency on rpcrt4, so
   // that this function is usable early in DllMain().
-  base::RandBytes(base::byte_span_from_ref(*this));
+  base::RandBytes(as_writable_bytes(span_from_ref(*this)));
 
   // Set six bits per RFC 4122 §4.4 to identify this as a pseudo-random UUID.
   data_3 = (4 << 12) | (data_3 & 0x0fff);  // §4.1.3

--- a/util/misc/uuid.cc
+++ b/util/misc/uuid.cc
@@ -121,7 +121,7 @@ bool UUID::InitializeWithNew() {
   // from libuuid is not available everywhere.
   // On Windows, do not use UuidCreate() to avoid a dependency on rpcrt4, so
   // that this function is usable early in DllMain().
-  base::RandBytes(base::as_writable_bytes(base::span_from_ref(*this)));
+  base::RandBytes(base::byte_span_from_ref(*this));
 
   // Set six bits per RFC 4122 §4.4 to identify this as a pseudo-random UUID.
   data_3 = (4 << 12) | (data_3 & 0x0fff);  // §4.1.3

--- a/util/misc/uuid.cc
+++ b/util/misc/uuid.cc
@@ -121,7 +121,7 @@ bool UUID::InitializeWithNew() {
   // from libuuid is not available everywhere.
   // On Windows, do not use UuidCreate() to avoid a dependency on rpcrt4, so
   // that this function is usable early in DllMain().
-  base::RandBytes(as_writable_bytes(span_from_ref(*this)));
+  base::RandBytes(base::as_writable_bytes(base::span_from_ref(*this)));
 
   // Set six bits per RFC 4122 §4.4 to identify this as a pseudo-random UUID.
   data_3 = (4 << 12) | (data_3 & 0x0fff);  // §4.1.3


### PR DESCRIPTION
crashpad increasingly depends on C++20 features through its base-library `mini_chromium`.
    
 This change vendors a `mini_chromium` fork compatible with C++17 compilers and removes the dependency on `std::ranges` in the `crashpad` UUID utilities.

The corresponding `mini_chromium` change is: https://github.com/getsentry/mini_chromium/pull/1 

This change is based on upstream `mini_chromium` [revision bd56f6](https://chromium.googlesource.com/chromium/mini_chromium/+/bd56f6933f2fa021a44766ced638a18f477ef1c1) which is also the `getsentry` branch-base of our fork.
