### PR TITLE
feat: parse <empty> proxy on Linux

### DIFF
--- a/client/client_argv_handling.cc
+++ b/client/client_argv_handling.cc
@@ -56,7 +56,12 @@ std::vector<std::string> BuildHandlerArgvStrings(
   }
 
   if (!http_proxy.empty()) {
-    argv_strings.push_back(FormatArgumentString("http-proxy", http_proxy));
+    // explicitly set an empty proxy to avoid reading from env. vars.
+    if(http_proxy == "<empty>"){
+      argv_strings.push_back(FormatArgumentString("http-proxy", ""));
+    }else{
+      argv_strings.push_back(FormatArgumentString("http-proxy", http_proxy));
+    }
   }
 
   for (const auto& kv : annotations) {

--- a/client/client_argv_handling.cc
+++ b/client/client_argv_handling.cc
@@ -56,12 +56,7 @@ std::vector<std::string> BuildHandlerArgvStrings(
   }
 
   if (!http_proxy.empty()) {
-    // explicitly set an empty proxy to avoid reading from env. vars.
-    if(http_proxy == "<empty>"){
-      argv_strings.push_back(FormatArgumentString("http-proxy", ""));
-    }else{
-      argv_strings.push_back(FormatArgumentString("http-proxy", http_proxy));
-    }
+    argv_strings.push_back(FormatArgumentString("http-proxy", http_proxy));
   }
 
   for (const auto& kv : annotations) {

--- a/util/net/http_transport_libcurl.cc
+++ b/util/net/http_transport_libcurl.cc
@@ -459,7 +459,9 @@ bool HTTPTransportLibcurl::ExecuteSynchronously(std::string* response_body) {
   TRY_CURL_EASY_SETOPT(curl.get(), CURLOPT_WRITEFUNCTION, WriteResponseBody);
   TRY_CURL_EASY_SETOPT(curl.get(), CURLOPT_WRITEDATA, response_body);
   if (!http_proxy().empty()) {
-    TRY_CURL_EASY_SETOPT(curl.get(), CURLOPT_PROXY, http_proxy().c_str());
+    // An empty string is a special value that libcurl interprets as “no proxy”.
+    const char* proxy = http_proxy() == "<empty>" ? "" : http_proxy().c_str();
+    TRY_CURL_EASY_SETOPT(curl.get(), CURLOPT_PROXY, proxy);
   }
 
 #undef TRY_CURL_EASY_SETOPT


### PR DESCRIPTION
Part of https://github.com/getsentry/sentry-native/pull/1111

Related to [this change](https://github.com/getsentry/sentry-native/blob/93678e063f9d6a2b68be912a624f6e9335e8b703/src/backends/sentry_backend_crashpad.cpp#L448-L453) in `sentry_backend_crashpad` 