### PR TITLE
feat: add option to delay shutdown until upload thread completes

### DIFF
--- a/client/crashpad_client.h
+++ b/client/crashpad_client.h
@@ -132,7 +132,8 @@ class CrashpadClient {
                     const std::vector<std::string>& arguments,
                     bool restartable,
                     bool asynchronous_start,
-                    const std::vector<base::FilePath>& attachments = {});
+                    const std::vector<base::FilePath>& attachments = {},
+                    bool wait_for_upload = false);
 
 #if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || \
     DOXYGEN

--- a/client/crashpad_client.h
+++ b/client/crashpad_client.h
@@ -137,7 +137,7 @@ class CrashpadClient {
                     bool restartable,
                     bool asynchronous_start,
                     const std::vector<base::FilePath>& attachments = {},
-                    const base::FilePath& screenshot = base::FilePath());
+                    const base::FilePath& screenshot = base::FilePath(),
                     bool wait_for_upload = false);
 
 #if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || \

--- a/client/crashpad_client_linux.cc
+++ b/client/crashpad_client_linux.cc
@@ -477,7 +477,8 @@ bool CrashpadClient::StartHandler(
     const std::vector<std::string>& arguments,
     bool restartable,
     bool asynchronous_start,
-    const std::vector<base::FilePath>& attachments) {
+    const std::vector<base::FilePath>& attachments,
+    bool wait_for_upload) {
   DCHECK(!asynchronous_start);
 
   ScopedFileHandle client_sock, handler_sock;
@@ -497,6 +498,9 @@ bool CrashpadClient::StartHandler(
 
   argv.push_back(FormatArgumentInt("initial-client-fd", handler_sock.get()));
   argv.push_back("--shared-client-connection");
+  if(wait_for_upload) {
+    argv.push_back("--wait-for-upload");
+  }
   if (!SpawnSubprocess(argv, nullptr, handler_sock.get(), false, nullptr)) {
     return false;
   }

--- a/client/crashpad_client_linux.cc
+++ b/client/crashpad_client_linux.cc
@@ -478,7 +478,7 @@ bool CrashpadClient::StartHandler(
     bool restartable,
     bool asynchronous_start,
     const std::vector<base::FilePath>& attachments,
-    const base::FilePath& screenshot) {
+    const base::FilePath& screenshot,
     bool wait_for_upload) {
   DCHECK(!asynchronous_start);
 

--- a/client/crashpad_client_mac.cc
+++ b/client/crashpad_client_mac.cc
@@ -482,7 +482,10 @@ bool CrashpadClient::StartHandler(
     const std::vector<std::string>& arguments,
     bool restartable,
     bool asynchronous_start,
-    const std::vector<base::FilePath>& attachments) {
+    const std::vector<base::FilePath>& attachments,
+    bool wait_for_upload) {
+  (void) wait_for_upload; // unused in mac (for now)
+
   // The “restartable” behavior can only be selected on OS X 10.10 and later. In
   // previous OS versions, if the initial client were to crash while attempting
   // to restart the handler, it would become an unkillable process.

--- a/client/crashpad_client_win.cc
+++ b/client/crashpad_client_win.cc
@@ -637,7 +637,9 @@ bool CrashpadClient::StartHandler(
     const std::vector<std::string>& arguments,
     bool restartable,
     bool asynchronous_start,
-    const std::vector<base::FilePath>& attachments) {
+    const std::vector<base::FilePath>& attachments,
+    bool wait_for_upload) {
+  (void) wait_for_upload; // unused in win (for now)
   DCHECK(ipc_pipe_.empty());
 
   // Both the pipe and the signalling events have to be created on the main

--- a/handler/handler_main.cc
+++ b/handler/handler_main.cc
@@ -257,6 +257,9 @@ struct Options {
 #if defined(ATTACHMENTS_SUPPORTED)
   std::vector<base::FilePath> attachments;
 #endif  // ATTACHMENTS_SUPPORTED
+#if BUILDFLAG(IS_LINUX)
+  bool wait_for_upload = false;
+#endif
 };
 
 // Splits |key_value| on '=' and inserts the resulting key and value into |map|.
@@ -632,6 +635,9 @@ int HandlerMain(int argc,
 #if BUILDFLAG(IS_ANDROID)
     kOptionWriteMinidumpToLog,
 #endif  // BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_LINUX)
+  kOptionWaitForUpload,
+#endif
 
     // Standard options.
     kOptionHelp = -2,
@@ -723,6 +729,9 @@ int HandlerMain(int argc,
 #if BUILDFLAG(IS_ANDROID)
     {"write-minidump-to-log", no_argument, nullptr, kOptionWriteMinidumpToLog},
 #endif  // BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_LINUX)
+  {"wait-for-upload", optional_argument, nullptr, kOptionWaitForUpload},
+#endif
     {"help", no_argument, nullptr, kOptionHelp},
     {"version", no_argument, nullptr, kOptionVersion},
     {nullptr, 0, nullptr, 0},
@@ -907,6 +916,12 @@ int HandlerMain(int argc,
         break;
       }
 #endif  // BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_LINUX)
+      case kOptionWaitForUpload : {
+        options.wait_for_upload = true;
+        break;
+      }
+#endif
       case kOptionHelp: {
         Usage(me);
         MetricsRecordExit(Metrics::LifetimeMilestone::kExitedEarly);
@@ -1092,7 +1107,12 @@ int HandlerMain(int argc,
       true,
       false,
 #endif  // BUILDFLAG(IS_LINUX)
-      user_stream_sources);
+      user_stream_sources
+#if BUILDFLAG(IS_LINUX)
+      ,options.wait_for_upload);
+#else
+  );
+#endif
 #endif  // BUILDFLAG(IS_CHROMEOS_ASH) || BUILDFLAG(IS_CHROMEOS_LACROS)
 
 #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)

--- a/handler/handler_main.cc
+++ b/handler/handler_main.cc
@@ -1109,10 +1109,9 @@ int HandlerMain(int argc,
 #endif  // BUILDFLAG(IS_LINUX)
       user_stream_sources
 #if BUILDFLAG(IS_LINUX)
-      ,options.wait_for_upload);
-#else
-  );
+      ,options.wait_for_upload
 #endif
+  );
 #endif  // BUILDFLAG(IS_CHROMEOS_ASH) || BUILDFLAG(IS_CHROMEOS_LACROS)
 
 #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)

--- a/handler/linux/crash_report_exception_handler.cc
+++ b/handler/linux/crash_report_exception_handler.cc
@@ -106,14 +106,16 @@ CrashReportExceptionHandler::CrashReportExceptionHandler(
     const std::vector<base::FilePath>* attachments,
     bool write_minidump_to_database,
     bool write_minidump_to_log,
-    const UserStreamDataSources* user_stream_data_sources)
+    const UserStreamDataSources* user_stream_data_sources,
+    bool wait_for_upload)
     : database_(database),
       upload_thread_(upload_thread),
       process_annotations_(process_annotations),
       attachments_(attachments),
       write_minidump_to_database_(write_minidump_to_database),
       write_minidump_to_log_(write_minidump_to_log),
-      user_stream_data_sources_(user_stream_data_sources) {
+      user_stream_data_sources_(user_stream_data_sources),
+      wait_for_upload_(wait_for_upload){
   DCHECK(write_minidump_to_database_ | write_minidump_to_log_);
 }
 
@@ -199,7 +201,7 @@ bool CrashReportExceptionHandler::HandleExceptionWithConnection(
                                   sanitized_snapshot.get());
 
   // Force flush only if WriteMinidumpToDatabase was successful
-  if (write_minidump_to_database_ && result) {
+  if (wait_for_upload_ && write_minidump_to_database_ && result) {
     // Flushes upload thread, forcing the handler to wait for one
     // upload attempt if there is a pending report, before sending SIGCONT to app.
     // Without this, SIGCONT is sent during the uploading, app crashes and UploadThread gets a SIGKILL.
@@ -317,7 +319,7 @@ bool CrashReportExceptionHandler::WriteMinidumpToLog(
 
 //  Force Crashpad Handler to wait for one upload attempt if there is a pending report
 void CrashReportExceptionHandler::FlushUploadThread() {
-  if (upload_thread_->is_running()) {
+  if (upload_thread_ && upload_thread_->is_running()) {
     // Following "Stop" call terminates the upload thread after completing whatever task it is
     // performing e.g. uploading a report. If it is not performing any task, it will terminate
     // immediately. It blocks while waiting for the upload thread to terminate making

--- a/handler/linux/crash_report_exception_handler.cc
+++ b/handler/linux/crash_report_exception_handler.cc
@@ -188,13 +188,24 @@ bool CrashReportExceptionHandler::HandleExceptionWithConnection(
     process_snapshot->SetClientID(client_id);
   }
 
-  return write_minidump_to_database_
+  // Force Crashpad Handler to wait for one upload attempt if there is a pending report
+  // TODO make this an option + add it to the other handlers (win/mac)
+  bool result =  write_minidump_to_database_
              ? WriteMinidumpToDatabase(process_snapshot.get(),
                                        sanitized_snapshot.get(),
                                        write_minidump_to_log_,
                                        local_report_id)
              : WriteMinidumpToLog(process_snapshot.get(),
                                   sanitized_snapshot.get());
+
+  // Force flush only if WriteMinidumpToDatabase was successful
+  if (write_minidump_to_database_ && result) {
+    // Flushes upload thread, forcing the handler to wait for one
+    // upload attempt if there is a pending report, before sending SIGCONT to app.
+    // Without this, SIGCONT is sent during the uploading, app crashes and UploadThread gets a SIGKILL.
+    this->FlushUploadThread();
+  }
+  return result;
 }
 
 bool CrashReportExceptionHandler::WriteMinidumpToDatabase(
@@ -301,6 +312,18 @@ bool CrashReportExceptionHandler::WriteMinidumpToLog(
     return false;
   }
   return writer.Flush();
+}
+
+
+//  Force Crashpad Handler to wait for one upload attempt if there is a pending report
+void CrashReportExceptionHandler::FlushUploadThread() {
+  if (upload_thread_->is_running()) {
+    // Following "Stop" call terminates the upload thread after completing whatever task it is
+    // performing e.g. uploading a report. If it is not performing any task, it will terminate
+    // immediately. It blocks while waiting for the upload thread to terminate making
+    // sure that the pending report (if any) is sent before returning.
+    upload_thread_->Stop();
+  }
 }
 
 }  // namespace crashpad

--- a/handler/linux/crash_report_exception_handler.h
+++ b/handler/linux/crash_report_exception_handler.h
@@ -108,6 +108,12 @@ class CrashReportExceptionHandler : public ExceptionHandlerServer::Delegate {
                                UUID* local_report_id);
   bool WriteMinidumpToLog(ProcessSnapshotLinux* process_snapshot,
                           ProcessSnapshotSanitized* sanitized_snapshot);
+  // Force Crashpad Handler to wait for one upload attempt if there is a pending report
+  /**
+   * Flush upload thread. If any report is being uploaded, this will
+   * block until an upload attempt is made.
+   */
+  void FlushUploadThread();
 
   CrashReportDatabase* database_;  // weak
   CrashReportUploadThread* upload_thread_;  // weak

--- a/handler/linux/crash_report_exception_handler.h
+++ b/handler/linux/crash_report_exception_handler.h
@@ -69,7 +69,8 @@ class CrashReportExceptionHandler : public ExceptionHandlerServer::Delegate {
       const std::vector<base::FilePath>* attachments,
       bool write_minidump_to_database,
       bool write_minidump_to_log,
-      const UserStreamDataSources* user_stream_data_sources);
+      const UserStreamDataSources* user_stream_data_sources,
+      bool wait_for_upload);
 
   CrashReportExceptionHandler(const CrashReportExceptionHandler&) = delete;
   CrashReportExceptionHandler& operator=(const CrashReportExceptionHandler&) =
@@ -122,6 +123,7 @@ class CrashReportExceptionHandler : public ExceptionHandlerServer::Delegate {
   bool write_minidump_to_database_;
   bool write_minidump_to_log_;
   const UserStreamDataSources* user_stream_data_sources_;  // weak
+  bool wait_for_upload_ = false;
 };
 
 }  // namespace crashpad


### PR DESCRIPTION
In some scenarios, waiting for the upload to complete makes more sense than trying to quickly kill the crashed process. 
Native PR https://github.com/getsentry/sentry-native/pull/1153

- [x] Make it an option