### PR TITLE
chore: update ubuntu runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,9 @@ jobs:
       matrix:
         include:
           - name: Ubuntu (GCC 14.2.0)
-          - platform: ubuntu-24.04
-          - CC: gcc-14
-          - CXX: g++-14
+            platform: ubuntu-24.04
+            CC: gcc-14
+            CXX: g++-14
           - name: Ubuntu (GCC 13.3.0)
             platform: ubuntu-24.04
             CC: gcc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: Ubuntu (GCC 14.2.0)
+          - platform: ubuntu-24.04
+          - CC: gcc-14
+          - CXX: g++-14
           - name: Ubuntu (GCC 13.3.0)
             platform: ubuntu-24.04
             CC: gcc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
             platform: ubuntu-22.04
             CC: gcc
             CXX: g++
-          - name: Ubuntu (GCC 9.4.0)
+          - name: Ubuntu (GCC 9.5.0)
             platform: ubuntu-22.04
             CC: gcc-9
             CXX: g++-9

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,9 @@ jobs:
             CC: gcc
             CXX: g++
           - name: Ubuntu (GCC 9.4.0)
-            platform: ubuntu-20.04
-            CC: gcc
-            CXX: g++
+            platform: ubuntu-22.04
+            CC: gcc-9
+            CXX: g++-9
           - name: Ubuntu (clang 18.1.3)
             platform: ubuntu-24.04
             CC: clang


### PR DESCRIPTION
Due to upcoming [deprecation of the 20.4 runners](https://github.com/actions/runner-images/issues/11101#issue-2719265843) we update our CI.