### PR TITLE
feat: screenshot capture (windows)

### DIFF
--- a/README.getsentry.md
+++ b/README.getsentry.md
@@ -6,6 +6,7 @@
   libc versions.
 - Build System Changes Listed Below.
 - MinGW build support.
+- Screenshot support for Windows.
 
 # Build System Changes
 

--- a/client/crashpad_client.h
+++ b/client/crashpad_client.h
@@ -121,6 +121,8 @@ class CrashpadClient {
   //!     option is only used on Windows.
   //! \param[in] attachments Vector that stores file paths that should be
   //!     captured with each report at the time of the crash.
+  //! \param[in] screenshot The path to a screenshot that should be
+  //!     captured with each report at the time of the crash.
   //!
   //! \return `true` on success, `false` on failure with a message logged.
   bool StartHandler(const base::FilePath& handler,
@@ -132,7 +134,8 @@ class CrashpadClient {
                     const std::vector<std::string>& arguments,
                     bool restartable,
                     bool asynchronous_start,
-                    const std::vector<base::FilePath>& attachments = {});
+                    const std::vector<base::FilePath>& attachments = {},
+                    const base::FilePath& screenshot = base::FilePath());
 
 #if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || \
     DOXYGEN

--- a/client/crashpad_client_linux.cc
+++ b/client/crashpad_client_linux.cc
@@ -477,7 +477,8 @@ bool CrashpadClient::StartHandler(
     const std::vector<std::string>& arguments,
     bool restartable,
     bool asynchronous_start,
-    const std::vector<base::FilePath>& attachments) {
+    const std::vector<base::FilePath>& attachments,
+    const base::FilePath& screenshot) {
   DCHECK(!asynchronous_start);
 
   ScopedFileHandle client_sock, handler_sock;

--- a/client/crashpad_client_mac.cc
+++ b/client/crashpad_client_mac.cc
@@ -482,7 +482,8 @@ bool CrashpadClient::StartHandler(
     const std::vector<std::string>& arguments,
     bool restartable,
     bool asynchronous_start,
-    const std::vector<base::FilePath>& attachments) {
+    const std::vector<base::FilePath>& attachments,
+    const base::FilePath& screenshot) {
   // The “restartable” behavior can only be selected on OS X 10.10 and later. In
   // previous OS versions, if the initial client were to crash while attempting
   // to restart the handler, it would become an unkillable process.

--- a/client/crashpad_client_win.cc
+++ b/client/crashpad_client_win.cc
@@ -355,6 +355,7 @@ struct BackgroundHandlerStartThreadData {
       const std::map<std::string, std::string>& annotations,
       const std::vector<std::string>& arguments,
       const std::vector<base::FilePath>& attachments,
+      const base::FilePath& screenshot,
       const std::wstring& ipc_pipe,
       ScopedFileHANDLE ipc_pipe_handle)
       : handler(handler),
@@ -365,6 +366,7 @@ struct BackgroundHandlerStartThreadData {
         annotations(annotations),
         arguments(arguments),
         attachments(attachments),
+        screenshot(screenshot),
         ipc_pipe(ipc_pipe),
         ipc_pipe_handle(std::move(ipc_pipe_handle)) {}
 
@@ -376,6 +378,7 @@ struct BackgroundHandlerStartThreadData {
   std::map<std::string, std::string> annotations;
   std::vector<std::string> arguments;
   std::vector<base::FilePath> attachments;
+  base::FilePath screenshot;
   std::wstring ipc_pipe;
   ScopedFileHANDLE ipc_pipe_handle;
 };
@@ -442,6 +445,11 @@ bool StartHandlerProcess(
   for (const base::FilePath& attachment : data->attachments) {
     AppendCommandLineArgument(
         FormatArgumentString("attachment", attachment.value()), &command_line);
+  }
+  if (!data->screenshot.empty()) {
+    AppendCommandLineArgument(
+        FormatArgumentString("screenshot", data->screenshot.value()),
+        &command_line);
   }
 
   ScopedKernelHANDLE this_process(
@@ -637,7 +645,8 @@ bool CrashpadClient::StartHandler(
     const std::vector<std::string>& arguments,
     bool restartable,
     bool asynchronous_start,
-    const std::vector<base::FilePath>& attachments) {
+    const std::vector<base::FilePath>& attachments,
+    const base::FilePath& screenshot) {
   DCHECK(ipc_pipe_.empty());
 
   // Both the pipe and the signalling events have to be created on the main
@@ -669,6 +678,7 @@ bool CrashpadClient::StartHandler(
                                                    annotations,
                                                    arguments,
                                                    attachments,
+                                                   screenshot,
                                                    ipc_pipe_,
                                                    std::move(ipc_pipe_handle));
 

--- a/handler/handler_main.cc
+++ b/handler/handler_main.cc
@@ -98,6 +98,9 @@ namespace {
 #define ATTACHMENTS_SUPPORTED 1
 #endif  // BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) ||
         // BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_APPLE)
+#if BUILDFLAG(IS_WIN)
+#define SCREENSHOT_SUPPORTED 1
+#endif  // BUILDFLAG(IS_WIN)
 
 void Usage(const base::FilePath& me) {
   // clang-format off
@@ -113,6 +116,12 @@ void Usage(const base::FilePath& me) {
 "                              at the time of the crash\n"
   // clang-format on
 #endif  // ATTACHMENTS_SUPPORTED
+#if defined(SCREENSHOT_SUPPORTED)
+      // clang-format off
+"      --screenshot=FILE_PATH  capture a screenshot to FILE_PATH\n"
+"                              at the time of the crash\n"
+  // clang-format on
+#endif  // SCREENSHOT_SUPPORTED
       // clang-format off
 "      --database=PATH         store the crash report database at PATH\n"
   // clang-format on
@@ -257,6 +266,9 @@ struct Options {
 #if defined(ATTACHMENTS_SUPPORTED)
   std::vector<base::FilePath> attachments;
 #endif  // ATTACHMENTS_SUPPORTED
+#if defined(SCREENSHOT_SUPPORTED)
+  base::FilePath screenshot;
+#endif  // SCREENSHOT_SUPPORTED
 };
 
 // Splits |key_value| on '=' and inserts the resulting key and value into |map|.
@@ -586,6 +598,9 @@ int HandlerMain(int argc,
 #if defined(ATTACHMENTS_SUPPORTED)
     kOptionAttachment,
 #endif  // ATTACHMENTS_SUPPORTED
+#if defined(SCREENSHOT_SUPPORTED)
+    kOptionScreenshot,
+#endif  // SCREENSHOT_SUPPORTED
     kOptionDatabase,
 #if BUILDFLAG(IS_APPLE)
     kOptionHandshakeFD,
@@ -643,6 +658,9 @@ int HandlerMain(int argc,
 #if defined(ATTACHMENTS_SUPPORTED)
     {"attachment", required_argument, nullptr, kOptionAttachment},
 #endif  // ATTACHMENTS_SUPPORTED
+#if defined(SCREENSHOT_SUPPORTED)
+    {"screenshot", required_argument, nullptr, kOptionScreenshot},
+#endif  // SCREENSHOT_SUPPORTED
     {"database", required_argument, nullptr, kOptionDatabase},
 #if BUILDFLAG(IS_APPLE)
     {"handshake-fd", required_argument, nullptr, kOptionHandshakeFD},
@@ -759,6 +777,13 @@ int HandlerMain(int argc,
         break;
       }
 #endif  // ATTACHMENTS_SUPPORTED
+#if defined(SCREENSHOT_SUPPORTED)
+      case kOptionScreenshot: {
+        options.screenshot = base::FilePath(
+            ToolSupport::CommandLineArgumentToFilePathStringType(optarg));
+        break;
+      }
+#endif  // SCREENSHOT_SUPPORTED
       case kOptionDatabase: {
         options.database = base::FilePath(
             ToolSupport::CommandLineArgumentToFilePathStringType(optarg));
@@ -1084,6 +1109,9 @@ int HandlerMain(int argc,
 #if defined(ATTACHMENTS_SUPPORTED)
       &options.attachments,
 #endif  // ATTACHMENTS_SUPPORTED
+#if defined(SCREENSHOT_SUPPORTED)
+      &options.screenshot,
+#endif  // SCREENSHOT_SUPPORTED
 #if BUILDFLAG(IS_ANDROID)
       options.write_minidump_to_database,
       options.write_minidump_to_log,

--- a/handler/win/crash_report_exception_handler.h
+++ b/handler/win/crash_report_exception_handler.h
@@ -60,6 +60,7 @@ class CrashReportExceptionHandler final
       CrashReportUploadThread* upload_thread,
       const std::map<std::string, std::string>* process_annotations,
       const std::vector<base::FilePath>* attachments,
+      const base::FilePath* screenshot,
       const UserStreamDataSources* user_stream_data_sources);
 
   CrashReportExceptionHandler(const CrashReportExceptionHandler&) = delete;
@@ -83,6 +84,7 @@ class CrashReportExceptionHandler final
   CrashReportUploadThread* upload_thread_;  // weak
   const std::map<std::string, std::string>* process_annotations_;  // weak
   const std::vector<base::FilePath>* attachments_;  // weak
+  const base::FilePath* screenshot_;  // weak
   const UserStreamDataSources* user_stream_data_sources_;  // weak
 };
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -368,6 +368,8 @@ if(WIN32)
         win/scoped_registry_key.h
         win/scoped_set_event.cc
         win/scoped_set_event.h
+        win/screenshot.cc
+        win/screenshot.h
         win/session_end_watcher.cc
         win/session_end_watcher.h
         win/termination_codes.h

--- a/util/win/screenshot.cc
+++ b/util/win/screenshot.cc
@@ -1,0 +1,181 @@
+// Copyright 2015 The Crashpad Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/win/screenshot.h"
+
+#include "base/logging.h"
+#include "util/win/get_function.h"
+
+#ifndef DWMWA_EXTENDED_FRAME_BOUNDS
+#define DWMWA_EXTENDED_FRAME_BOUNDS 9
+#endif
+
+enum GpStatus { GpOk = 0 };
+struct GdiplusStartupInput {
+  UINT32 GdiplusVersion;
+  PVOID DebugEventCallback;
+  BOOL SuppressBackgroundThread;
+  BOOL SuppressExternalCodecs;
+};
+using GpBitmap = void;
+using GpImage = void;
+
+extern "C" {
+GpStatus WINAPI GdiplusStartup(ULONG_PTR* token,
+                               const GdiplusStartupInput* input,
+                               void* output);
+GpStatus WINAPI GdipCreateBitmapFromHBITMAP(HBITMAP hbm,
+                                            HPALETTE hpal,
+                                            GpBitmap** bitmap);
+GpStatus WINAPI GdipSaveImageToFile(GpImage* image,
+                                    const wchar_t* filename,
+                                    const CLSID* encoder,
+                                    const void* params);
+GpStatus WINAPI GdipDisposeImage(GpImage* image);
+HRESULT WINAPI DwmGetWindowAttribute(HWND hwnd,
+                                     DWORD dwAttribute,
+                                     PVOID pvAttribute,
+                                     DWORD cbAttribute);
+}
+
+namespace crashpad {
+
+namespace {
+bool SaveBitmap(HBITMAP bitmap, const wchar_t* path) {
+  const auto gdiplus_startup = GET_FUNCTION(L"gdiplus.dll", ::GdiplusStartup);
+  if (!gdiplus_startup) {
+    PLOG(WARNING) << "GdiplusStartup";
+    return false;
+  }
+
+  const auto gdip_create_bitmap_from_hbitmap =
+      GET_FUNCTION(L"gdiplus.dll", ::GdipCreateBitmapFromHBITMAP);
+  if (!gdip_create_bitmap_from_hbitmap) {
+    PLOG(WARNING) << "GdipCreateBitmapFromHBITMAP";
+    return false;
+  }
+
+  const auto gdip_save_image_to_file =
+      GET_FUNCTION(L"gdiplus.dll", ::GdipSaveImageToFile);
+  if (!gdip_save_image_to_file) {
+    PLOG(WARNING) << "GdipSaveImageToFile";
+    return false;
+  }
+
+  const auto gdip_dispose_image =
+      GET_FUNCTION(L"gdiplus.dll", ::GdipDisposeImage);
+  if (!gdip_dispose_image) {
+    PLOG(WARNING) << "GdipDisposeImage";
+    return false;
+  }
+
+  GdiplusStartupInput input;
+  ZeroMemory(&input, sizeof(input));
+  input.GdiplusVersion = 1;
+
+  ULONG_PTR token = 0;
+  if (gdiplus_startup(&token, &input, nullptr) != GpOk) {
+    PLOG(WARNING) << "GdiplusStartup";
+    return false;
+  }
+
+  GpImage* image = NULL;
+  if (gdip_create_bitmap_from_hbitmap(bitmap, nullptr, &image) != GpOk) {
+    PLOG(WARNING) << "GdipCreateBitmapFromHBITMAP";
+    return false;
+  }
+
+  // CLSIDFromString(L"{557cf406-1a04-11d3-9a73-0000f81ef32e}")
+  const CLSID GdiPngEncoder = {
+      0x557cf406,
+      0x1a04,
+      0x11d3,
+      {0x9a, 0x73, 0x00, 0x00, 0xf8, 0x1e, 0xf3, 0x2e}};
+  GpStatus rv = gdip_save_image_to_file(image, path, &GdiPngEncoder, nullptr);
+  if (rv != GpOk) {
+    PLOG(WARNING) << "GdipSaveImageToFile";
+  }
+
+  if (gdip_dispose_image(image) != GpOk) {
+    PLOG(WARNING) << "GdipDisposeImage";
+  }
+
+  return rv == GpOk;
+}
+
+void CalculateRegion(DWORD pid, HRGN region) {
+  const auto dwm_get_window_attribute =
+      GET_FUNCTION(L"dwmapi.dll", ::DwmGetWindowAttribute);
+  if (!dwm_get_window_attribute) {
+    PLOG(WARNING) << "DwmGetWindowAttribute";
+    return;
+  }
+
+  HWND hwnd = GetShellWindow();
+  while (hwnd) {
+    if (IsWindowVisible(hwnd)) {
+      RECT frame = {0};
+      dwm_get_window_attribute(
+          hwnd, DWMWA_EXTENDED_FRAME_BOUNDS, &frame, sizeof(RECT));
+      if (frame.right > frame.left && frame.bottom > frame.top) {
+        DWORD wpid = 0;
+        GetWindowThreadProcessId(hwnd, &wpid);
+        HRGN wregion = CreateRectRgnIndirect(&frame);
+        if (wpid == pid) {
+          CombineRgn(region, region, wregion, RGN_OR);
+        } else {
+          CombineRgn(region, region, wregion, RGN_DIFF);
+        }
+        DeleteObject(wregion);
+      }
+    }
+    hwnd = GetWindow(hwnd, GW_HWNDPREV);
+  }
+}
+}  // namespace
+
+bool CaptureScreenshot(ProcessID process_id, const base::FilePath& path) {
+  HRGN region = CreateRectRgn(0, 0, 0, 0);
+  CalculateRegion(process_id, region);
+
+  RECT box;
+  GetRgnBox(region, &box);
+  LONG width = box.right - box.left;
+  LONG height = box.bottom - box.top;
+  if (width <= 0 || height <= 0) {
+    DeleteObject(region);
+    return false;
+  }
+
+  HDC src = GetDC(NULL);
+  HDC hdc = CreateCompatibleDC(src);
+  HBITMAP bitmap = CreateCompatibleBitmap(src, width, height);
+  SelectObject(hdc, bitmap);
+  OffsetRgn(region, -box.left, -box.top);
+  SelectClipRgn(hdc, region);
+  BitBlt(hdc, 0, 0, width, height, src, box.left, box.top, SRCCOPY);
+
+  bool rv = SaveBitmap(bitmap, path.value().c_str());
+  if (!rv) {
+    LOG(WARNING) << "Failed to save screenshot: " << path;
+  }
+
+  DeleteObject(bitmap);
+  DeleteDC(hdc);
+  ReleaseDC(NULL, src);
+  DeleteObject(region);
+  return rv;
+}
+
+}  // namespace crashpad

--- a/util/win/screenshot.h
+++ b/util/win/screenshot.h
@@ -1,0 +1,32 @@
+// Copyright 2015 The Crashpad Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CRASHPAD_UTIL_WIN_SCREENSHOT_H_
+#define CRASHPAD_UTIL_WIN_SCREENSHOT_H_
+
+#include "base/files/file_path.h"
+#include "util/process/process_id.h"
+
+namespace crashpad {
+
+//! \brief Utility function for capturing screenshots on Windows.
+//!
+//! \param[in] process_id The process ID to capture the screenshot of.
+//! \param[in] path The path to save the screenshot to.
+//! \return `true` on success. `false` on failure with a message logged.
+bool CaptureScreenshot(ProcessID process_id, const base::FilePath& path);
+
+}  // namespace crashpad
+
+#endif  // CRASHPAD_UTIL_WIN_SCREENSHOT_H_


### PR DESCRIPTION
Allows capturing screenshots of fast-fail crashes on Windows (getsentry/sentry-native#693).