### PR TITLE
fix: compilation errors with musl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,16 @@ jobs:
             platform: ubuntu-22.04
             CC: clang
             CXX: clang++
+          - name: Alpine Linux (GCC + musl)
+            platform: ubuntu-latest
+            container: alpine:3.21
+            CC: gcc
+            CXX: g++
+          - name: Alpine Linux (clang + musl)
+            platform: ubuntu-latest
+            container: alpine:3.21
+            CC: clang
+            CXX: clang++
           - name: Windows (x64)
             platform: windows-latest
           - name: Windows ClangCL (x64)
@@ -59,15 +69,22 @@ jobs:
             platform: macos-latest
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.platform }}
+    container: ${{ matrix.container }}
     env:
       CMAKE_DEFINES: "${{ matrix.CMAKE_DEFINES }}"
     steps:
+      - name: Installing Alpine Linux Dependencies
+        if: ${{ contains(matrix.container, 'alpine') }}
+        run: |
+          apk update
+          apk add git bash build-base clang cmake zlib-dev curl-dev openssl-dev libunwind-dev linux-headers pkgconf
+
       - uses: actions/checkout@v4
         with:
           submodules: "recursive"
 
-      - name: Installing Linux Dependencies
-        if: ${{ runner.os == 'Linux' }}
+      - name: Installing Ubuntu Dependencies
+        if: ${{ runner.os == 'Linux' && !matrix.container }}
         run: |
           sudo apt update
           sudo apt install clang zlib1g-dev libcurl4-openssl-dev libssl-dev libunwind-dev pkg-config

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,14 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     )
 endif()
 
+if(LINUX)
+    target_compile_definitions(crashpad_interface INTERFACE
+        _FILE_OFFSET_BITS=64
+        _LARGEFILE64_SOURCE
+        _LARGEFILE_SOURCE
+    )
+endif()
+
 add_library(crashpad::interface ALIAS crashpad_interface)
 
 add_subdirectory(compat)

--- a/compat/linux/sys/ptrace.h
+++ b/compat/linux/sys/ptrace.h
@@ -17,7 +17,9 @@
 
 #include_next <sys/ptrace.h>
 
+#ifdef __GLIBC__
 #include <sys/cdefs.h>
+#endif
 
 // https://sourceware.org/bugzilla/show_bug.cgi?id=22433
 #if !defined(PTRACE_GET_THREAD_AREA) && !defined(PT_GET_THREAD_AREA) && \

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -95,6 +95,13 @@ if(CRASHPAD_BUILD_TOOLS)
             $<$<COMPILE_LANGUAGE:CXX>:-Wno-multichar>
         )
     endif()
+    if(LINUX)
+        target_compile_definitions(crashpad_generate_dump PRIVATE
+            _FILE_OFFSET_BITS=64
+            _LARGEFILE64_SOURCE
+            _LARGEFILE_SOURCE
+        )
+    endif()
     crashpad_install_target(crashpad_generate_dump)
 
     if(APPLE)


### PR DESCRIPTION
This PR fixes the following compile errors with musl:

1. crashpad includes glibc-specific `<sys/cdefs.h>` without appropriate `__GLIBC__` guard

    ```sh
    In file included from sentry-native/external/crashpad/util/linux/scoped_ptrace_attach.cc:17:
    sentry-native/external/crashpad/compat/linux/sys/ptrace.h:20:10: fatal error: 
    sys/cdefs.h: No such file or directory
       20 | #include <sys/cdefs.h>
          |          ^~~~~~~~~~~~~
    ```

2. crashpad uses `pread64`, `off64_t` etc. that are only available in musl when `_LARGEFILE64_SOURCE` is defined

    ```sh
    In file included from sentry-native/external/crashpad/util/process/process_memory_linux.cc:27:
    sentry-native/external/crashpad/util/process/process_memory_linux.cc: In lambda function:
    sentry-native/external/crashpad/util/process/process_memory_linux.cc:48:24: error: 'pread64' was not declared in this scope; did you mean 'pread'?
       48 |           HANDLE_EINTR(pread64(mem_fd_.get(), buffer, size, address));
          |                        ^~~~~~~
    
    In file included from sentry-native/external/crashpad/util/linux/memory_map.cc:15:
    sentry-native/external/crashpad/util/linux/memory_map.h:46:5: error: 'off64_t' does not name a type; did you mean 'off_t'?
       46 |     off64_t offset;
          |     ^~~~~~~
          |     off_t
    ```

These fixes are needed for getsentry/sentry-native#1233 to pass the CI on Alpine Linux with musl.

Ref: getsentry/sentry-native#1232