### PR TITLE
feat: wait-for-upload Windows support

### DIFF
--- a/client/crashpad_client_win.cc
+++ b/client/crashpad_client_win.cc
@@ -356,6 +356,7 @@ struct BackgroundHandlerStartThreadData {
       const std::vector<std::string>& arguments,
       const std::vector<base::FilePath>& attachments,
       const base::FilePath& screenshot,
+      const bool wait_for_upload,
       const std::wstring& ipc_pipe,
       ScopedFileHANDLE ipc_pipe_handle)
       : handler(handler),
@@ -367,6 +368,7 @@ struct BackgroundHandlerStartThreadData {
         arguments(arguments),
         attachments(attachments),
         screenshot(screenshot),
+        wait_for_upload(wait_for_upload),
         ipc_pipe(ipc_pipe),
         ipc_pipe_handle(std::move(ipc_pipe_handle)) {}
 
@@ -379,6 +381,7 @@ struct BackgroundHandlerStartThreadData {
   std::vector<std::string> arguments;
   std::vector<base::FilePath> attachments;
   base::FilePath screenshot;
+  bool wait_for_upload;
   std::wstring ipc_pipe;
   ScopedFileHANDLE ipc_pipe_handle;
 };
@@ -450,6 +453,10 @@ bool StartHandlerProcess(
     AppendCommandLineArgument(
         FormatArgumentString("screenshot", data->screenshot.value()),
         &command_line);
+  }
+
+  if (data->wait_for_upload) {
+      AppendCommandLineArgument(L"--wait-for-upload", &command_line);
   }
 
   ScopedKernelHANDLE this_process(
@@ -648,7 +655,6 @@ bool CrashpadClient::StartHandler(
     const std::vector<base::FilePath>& attachments,
     const base::FilePath& screenshot,
     bool wait_for_upload) {
-  (void) wait_for_upload; // unused in win (for now)
   DCHECK(ipc_pipe_.empty());
 
   // Both the pipe and the signalling events have to be created on the main
@@ -681,6 +687,7 @@ bool CrashpadClient::StartHandler(
                                                    arguments,
                                                    attachments,
                                                    screenshot,
+                                                   wait_for_upload,
                                                    ipc_pipe_,
                                                    std::move(ipc_pipe_handle));
 

--- a/handler/crash_report_upload_thread.cc
+++ b/handler/crash_report_upload_thread.cc
@@ -116,6 +116,11 @@ void CrashReportUploadThread::ReportPending(const UUID& report_uuid) {
     thread_.DoWorkNow();
 }
 
+void CrashReportUploadThread::ReportPendingSync(const UUID& report_uuid) {
+  known_pending_report_uuids_.PushBack(report_uuid);
+  DoWork(nullptr);
+}
+
 void CrashReportUploadThread::Start() {
   thread_.Start(
       options_.watch_pending_reports ? 0.0 : WorkerThread::kIndefiniteWait);

--- a/handler/crash_report_upload_thread.h
+++ b/handler/crash_report_upload_thread.h
@@ -104,6 +104,16 @@ class CrashReportUploadThread : public WorkerThread::Delegate,
   //! This method may be called from any thread.
   void ReportPending(const UUID& report_uuid);
 
+  //! \brief Runs the upload on the calling thread rather than in the upload
+  //!     thread. This is only used from the exception handler to block the
+  //!     termination of the crashed process until the upload is completed.
+  //!
+  //! \param[in] report_uuid The unique identifier of the newly added pending
+  //!     report.
+  //!
+  //! This method will run on the pool thread executing the OnCrashDumpEvent
+  void ReportPendingSync(const UUID& report_uuid);
+
   // Stoppable:
 
   //! \brief Starts a dedicated upload thread, which executes ThreadMain().

--- a/handler/handler_main.cc
+++ b/handler/handler_main.cc
@@ -269,7 +269,7 @@ struct Options {
 #if defined(SCREENSHOT_SUPPORTED)
   base::FilePath screenshot;
 #endif  // SCREENSHOT_SUPPORTED
-#if BUILDFLAG(IS_LINUX)
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
   bool wait_for_upload = false;
 #endif
 };
@@ -650,7 +650,7 @@ int HandlerMain(int argc,
 #if BUILDFLAG(IS_ANDROID)
     kOptionWriteMinidumpToLog,
 #endif  // BUILDFLAG(IS_ANDROID)
-#if BUILDFLAG(IS_LINUX)
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
   kOptionWaitForUpload,
 #endif
 
@@ -747,8 +747,8 @@ int HandlerMain(int argc,
 #if BUILDFLAG(IS_ANDROID)
     {"write-minidump-to-log", no_argument, nullptr, kOptionWriteMinidumpToLog},
 #endif  // BUILDFLAG(IS_ANDROID)
-#if BUILDFLAG(IS_LINUX)
-  {"wait-for-upload", optional_argument, nullptr, kOptionWaitForUpload},
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
+  {"wait-for-upload", no_argument, nullptr, kOptionWaitForUpload},
 #endif
     {"help", no_argument, nullptr, kOptionHelp},
     {"version", no_argument, nullptr, kOptionVersion},
@@ -941,7 +941,7 @@ int HandlerMain(int argc,
         break;
       }
 #endif  // BUILDFLAG(IS_ANDROID)
-#if BUILDFLAG(IS_LINUX)
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
       case kOptionWaitForUpload : {
         options.wait_for_upload = true;
         break;
@@ -1136,7 +1136,7 @@ int HandlerMain(int argc,
       false,
 #endif  // BUILDFLAG(IS_LINUX)
       user_stream_sources
-#if BUILDFLAG(IS_LINUX)
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
       ,options.wait_for_upload
 #endif
   );

--- a/handler/win/crash_report_exception_handler.cc
+++ b/handler/win/crash_report_exception_handler.cc
@@ -40,12 +40,14 @@ CrashReportExceptionHandler::CrashReportExceptionHandler(
     const std::map<std::string, std::string>* process_annotations,
     const std::vector<base::FilePath>* attachments,
     const base::FilePath* screenshot,
-    const UserStreamDataSources* user_stream_data_sources)
+    const UserStreamDataSources* user_stream_data_sources,
+    const bool wait_for_upload)
     : database_(database),
       upload_thread_(upload_thread),
       process_annotations_(process_annotations),
       attachments_(attachments),
       screenshot_(screenshot),
+      wait_for_upload_(wait_for_upload),
       user_stream_data_sources_(user_stream_data_sources) {}
 
 CrashReportExceptionHandler::~CrashReportExceptionHandler() {}
@@ -160,7 +162,12 @@ unsigned int CrashReportExceptionHandler::ExceptionHandlerServerException(
     }
 
     if (upload_thread_) {
-      upload_thread_->ReportPending(uuid);
+      if (wait_for_upload_) {
+        upload_thread_->ReportPendingSync(uuid);
+      }
+      else {
+        upload_thread_->ReportPending(uuid);
+      }
     }
   }
 

--- a/handler/win/crash_report_exception_handler.h
+++ b/handler/win/crash_report_exception_handler.h
@@ -61,7 +61,8 @@ class CrashReportExceptionHandler final
       const std::map<std::string, std::string>* process_annotations,
       const std::vector<base::FilePath>* attachments,
       const base::FilePath* screenshot,
-      const UserStreamDataSources* user_stream_data_sources);
+      const UserStreamDataSources* user_stream_data_sources,
+      bool wait_for_upload);
 
   CrashReportExceptionHandler(const CrashReportExceptionHandler&) = delete;
   CrashReportExceptionHandler& operator=(const CrashReportExceptionHandler&) =
@@ -85,6 +86,7 @@ class CrashReportExceptionHandler final
   const std::map<std::string, std::string>* process_annotations_;  // weak
   const std::vector<base::FilePath>* attachments_;  // weak
   const base::FilePath* screenshot_;  // weak
+  const bool wait_for_upload_;
   const UserStreamDataSources* user_stream_data_sources_;  // weak
 };
 


### PR DESCRIPTION
Provide the parts necessary on the `crashpad` side to let Windows systems also wait for a completed upload before terminating the crashed application.