### PR TITLE
feat: support attaching bytes on Windows and Linux

### DIFF
--- a/client/crashpad_client.h
+++ b/client/crashpad_client.h
@@ -27,6 +27,7 @@
 #include "build/build_config.h"
 #include "build/chromeos_buildflags.h"
 #include "util/file/file_io.h"
+#include "util/misc/attachment.h"
 
 #if !BUILDFLAG(IS_FUCHSIA)
 #include "util/misc/capture_context.h"
@@ -841,17 +842,17 @@ class CrashpadClient {
 #endif
 
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX) || DOXYGEN
-  //! \brief Adds a file to the list of files to be attached to the crash
-  //!     report.
+  //! \brief Adds an attachment to the list of attachments to be attached
+  //!     to the crash report.
   //!
-  //! \param[in] attachment The path to the file to be added.
-  void AddAttachment(const base::FilePath& attachment);
+  //! \param[in] attachment The attachment to be added.
+  void AddAttachment(const Attachment& attachment);
 
-  //! \brief Removes a file from the list of files to be attached to the crash
-  //!     report.
+  //! \brief Removes an attachment from the list of attachments to be attached
+  //!     to the crash report.
   //!
-  //! \param[in] attachment The path to the file to be removed.
-  void RemoveAttachment(const base::FilePath& attachment);
+  //! \param[in] uuid The UUID of the attachment to be removed.
+  void RemoveAttachment(const UUID& uuid);
 #endif
 
  private:

--- a/client/crashpad_client_linux.cc
+++ b/client/crashpad_client_linux.cc
@@ -436,14 +436,14 @@ class RequestCrashDumpHandler : public SignalHandler {
   }
 #endif
 
-  void AddAttachment(const base::FilePath& attachment) {
+  void AddAttachment(const Attachment& attachment) {
     ExceptionHandlerClient client(sock_to_handler_.get(), true);
     client.AddAttachment(attachment);
   }
 
-  void RemoveAttachment(const base::FilePath& attachment) {
+  void RemoveAttachment(const UUID& uuid) {
     ExceptionHandlerClient client(sock_to_handler_.get(), true);
-    client.RemoveAttachment(attachment);
+    client.RemoveAttachment(uuid);
   }
 
  private:
@@ -817,14 +817,14 @@ void CrashpadClient::SetCrashLoopBefore(uint64_t crash_loop_before_time) {
 }
 #endif
 
-void CrashpadClient::AddAttachment(const base::FilePath& attachment) {
+void CrashpadClient::AddAttachment(const Attachment& attachment) {
   auto signal_handler = RequestCrashDumpHandler::Get();
   signal_handler->AddAttachment(attachment);
 }
 
-void CrashpadClient::RemoveAttachment(const base::FilePath& attachment) {
+void CrashpadClient::RemoveAttachment(const UUID& uuid) {
   auto signal_handler = RequestCrashDumpHandler::Get();
-  signal_handler->RemoveAttachment(attachment);
+  signal_handler->RemoveAttachment(uuid);
 }
 
 }  // namespace crashpad

--- a/client/crashpad_client_win.cc
+++ b/client/crashpad_client_win.cc
@@ -1183,20 +1183,26 @@ void CrashpadClient::SetFirstChanceExceptionHandler(
   first_chance_handler_ = handler;
 }
 
-void CrashpadClient::AddAttachment(const base::FilePath& attachment) {
+void CrashpadClient::AddAttachment(const Attachment& attachment) {
   ClientToServerMessage message = {};
   message.type = ClientToServerMessage::kAddAttachment;
   swprintf_s(
-      message.attachment.path, MAX_PATH, L"%ls", attachment.value().c_str());
+      message.attachment.path, MAX_PATH, L"%ls", attachment.GetPath().value().c_str());
+  message.attachment.uuid = attachment.GetUuid();
+  message.attachment.bytes = attachment.GetBytes().size();
   ServerToClientMessage response = {};
-  SendToCrashHandlerServer(ipc_pipe_, message, &response);
+  const std::vector<uint8_t>& bytes = attachment.GetBytes();
+  SendToCrashHandlerServerEx(ipc_pipe_,
+                              message,
+                              bytes.data(),
+                              bytes.size(),
+                              &response);
 }
 
-void CrashpadClient::RemoveAttachment(const base::FilePath& attachment) {
+void CrashpadClient::RemoveAttachment(const UUID& uuid) {
   ClientToServerMessage message = {};
   message.type = ClientToServerMessage::kRemoveAttachment;
-  swprintf_s(
-      message.attachment.path, MAX_PATH, L"%ls", attachment.value().c_str());
+  message.attachment.uuid = uuid;
   ServerToClientMessage response = {};
   SendToCrashHandlerServer(ipc_pipe_, message, &response);
 }

--- a/handler/linux/crash_report_exception_handler.cc
+++ b/handler/linux/crash_report_exception_handler.cc
@@ -111,12 +111,15 @@ CrashReportExceptionHandler::CrashReportExceptionHandler(
     : database_(database),
       upload_thread_(upload_thread),
       process_annotations_(process_annotations),
-      attachments_(*attachments),
       write_minidump_to_database_(write_minidump_to_database),
       write_minidump_to_log_(write_minidump_to_log),
       user_stream_data_sources_(user_stream_data_sources),
-      wait_for_upload_(wait_for_upload){
+      wait_for_upload_(wait_for_upload) {
   DCHECK(write_minidump_to_database_ | write_minidump_to_log_);
+  attachments_.reserve(attachments->size());
+  for (const auto& attachment : *attachments) {
+    attachments_.emplace_back(Attachment::FromPath(attachment));
+  }
 }
 
 CrashReportExceptionHandler::~CrashReportExceptionHandler() = default;
@@ -210,21 +213,25 @@ bool CrashReportExceptionHandler::HandleExceptionWithConnection(
   return result;
 }
 
-void CrashReportExceptionHandler::AddAttachment(
-    const base::FilePath& attachment) {
+void CrashReportExceptionHandler::AddAttachment(const Attachment& attachment) {
   auto it = std::find(attachments_.begin(), attachments_.end(), attachment);
   if (it != attachments_.end()) {
-    LOG(WARNING) << "ignoring duplicate attachment " << attachment;
+    LOG(WARNING) << "ignoring duplicate attachment "
+                 << attachment.GetUuid().ToString() << " ("
+                 << attachment.GetPath() << ")";
     return;
   }
   attachments_.push_back(attachment);
 }
 
-void CrashReportExceptionHandler::RemoveAttachment(
-    const base::FilePath& attachment) {
-  auto it = std::find(attachments_.begin(), attachments_.end(), attachment);
+void CrashReportExceptionHandler::RemoveAttachment(const UUID& uuid) {
+  auto it = std::find_if(attachments_.begin(),
+                         attachments_.end(),
+                         [uuid](const Attachment& attachment) {
+                           return attachment.GetUuid() == uuid;
+                         });
   if (it == attachments_.end()) {
-    LOG(WARNING) << "ignoring non-existent attachment " << attachment;
+    LOG(WARNING) << "ignoring non-existent attachment " << uuid.ToString();
     return;
   }
   attachments_.erase(it);
@@ -273,14 +280,7 @@ bool CrashReportExceptionHandler::WriteMinidumpToDatabase(
   }
 
   for (const auto& attachment : attachments_) {
-    FileReader file_reader;
-    if (!file_reader.Open(attachment)) {
-      LOG(ERROR) << "attachment " << attachment.value().c_str()
-                 << " couldn't be opened, skipping";
-      continue;
-    }
-
-    base::FilePath filename = attachment.BaseName();
+    base::FilePath filename = attachment.GetPath().BaseName();
     FileWriter* file_writer = new_report->AddAttachment(filename.value());
     if (file_writer == nullptr) {
       LOG(ERROR) << "attachment " << filename.value().c_str()
@@ -288,7 +288,18 @@ bool CrashReportExceptionHandler::WriteMinidumpToDatabase(
       continue;
     }
 
-    CopyFileContent(&file_reader, file_writer);
+    if (attachment.HasBytes()) {
+      const std::vector<uint8_t>& bytes = attachment.GetBytes();
+      file_writer->Write(bytes.data(), bytes.size() * sizeof(uint8_t));
+    } else {
+      FileReader file_reader;
+      if (!file_reader.Open(attachment.GetPath())) {
+        LOG(ERROR) << "attachment " << attachment.GetPath().value().c_str()
+                   << " couldn't be opened, skipping";
+        continue;
+      }
+      CopyFileContent(&file_reader, file_writer);
+    }
   }
 
   UUID uuid;

--- a/handler/linux/crash_report_exception_handler.h
+++ b/handler/linux/crash_report_exception_handler.h
@@ -26,6 +26,7 @@
 #include "util/linux/exception_handler_protocol.h"
 #include "util/linux/ptrace_connection.h"
 #include "util/misc/address_types.h"
+#include "util/misc/attachment.h"
 #include "util/misc/uuid.h"
 
 namespace crashpad {
@@ -95,8 +96,8 @@ class CrashReportExceptionHandler : public ExceptionHandlerServer::Delegate {
       int broker_sock,
       UUID* local_report_id = nullptr) override;
 
-  void AddAttachment(const base::FilePath& attachment) override;
-  void RemoveAttachment(const base::FilePath& attachment) override;
+  void AddAttachment(const Attachment& attachment) override;
+  void RemoveAttachment(const UUID& uuid) override;
 
  private:
   bool HandleExceptionWithConnection(
@@ -123,7 +124,7 @@ class CrashReportExceptionHandler : public ExceptionHandlerServer::Delegate {
   CrashReportDatabase* database_;  // weak
   CrashReportUploadThread* upload_thread_;  // weak
   const std::map<std::string, std::string>* process_annotations_;  // weak
-  std::vector<base::FilePath> attachments_;
+  std::vector<Attachment> attachments_;
   bool write_minidump_to_database_;
   bool write_minidump_to_log_;
   const UserStreamDataSources* user_stream_data_sources_;  // weak

--- a/handler/linux/exception_handler_server.cc
+++ b/handler/linux/exception_handler_server.cc
@@ -433,11 +433,29 @@ bool ExceptionHandlerServer::ReceiveClientMessage(Event* event) {
           event->type == Event::Type::kSharedSocketMessage);
 
     case ExceptionHandlerProtocol::ClientToServerMessage::kTypeAddAttachment:
-      delegate_->AddAttachment(base::FilePath(message.attachment_info.path));
+      if (message.attachment_info.bytes == 0) {
+        delegate_->AddAttachment(
+            Attachment(base::FilePath(message.attachment_info.path),
+                       message.attachment_info.uuid));
+      } else {
+        std::vector<uint8_t> bytes(message.attachment_info.bytes);
+        if (!UnixCredentialSocket::RecvMsg(event->fd.get(),
+                                           bytes.data(),
+                                           bytes.size() * sizeof(uint8_t),
+                                           &creds)) {
+          PLOG(ERROR) << "Failed to receive attachment ("
+                      << message.attachment_info.bytes << " bytes)";
+          return false;
+        }
+        delegate_->AddAttachment(
+            Attachment(bytes,
+                       base::FilePath(message.attachment_info.path),
+                       message.attachment_info.uuid));
+      }
       return true;
 
     case ExceptionHandlerProtocol::ClientToServerMessage::kTypeRemoveAttachment:
-      delegate_->RemoveAttachment(base::FilePath(message.attachment_info.path));
+      delegate_->RemoveAttachment(message.attachment_info.uuid);
       return true;
   }
 

--- a/handler/linux/exception_handler_server.h
+++ b/handler/linux/exception_handler_server.h
@@ -25,6 +25,7 @@
 #include "util/file/file_io.h"
 #include "util/linux/exception_handler_protocol.h"
 #include "util/misc/address_types.h"
+#include "util/misc/attachment.h"
 #include "util/misc/initialization_state_dcheck.h"
 #include "util/misc/uuid.h"
 
@@ -112,10 +113,10 @@ class ExceptionHandlerServer {
         UUID* local_report_id = nullptr) = 0;
 
     //! \brief Called to add an attachment to the crash report.
-    virtual void AddAttachment(const base::FilePath& attachment) = 0;
+    virtual void AddAttachment(const Attachment& attachment) = 0;
 
     //! \brief Called to remove an attachment from the crash report.
-    virtual void RemoveAttachment(const base::FilePath& attachment) = 0;
+    virtual void RemoveAttachment(const UUID& uuid) = 0;
 
     virtual ~Delegate() {}
   };

--- a/handler/win/crash_report_exception_handler.cc
+++ b/handler/win/crash_report_exception_handler.cc
@@ -45,10 +45,14 @@ CrashReportExceptionHandler::CrashReportExceptionHandler(
     : database_(database),
       upload_thread_(upload_thread),
       process_annotations_(process_annotations),
-      attachments_(*attachments),
       screenshot_(screenshot),
       wait_for_upload_(wait_for_upload),
-      user_stream_data_sources_(user_stream_data_sources) {}
+      user_stream_data_sources_(user_stream_data_sources) {
+  attachments_.reserve(attachments->size());
+  for (const auto& attachment : *attachments) {
+    attachments_.emplace_back(Attachment::FromPath(attachment));
+  }
+}
 
 CrashReportExceptionHandler::~CrashReportExceptionHandler() {}
 
@@ -118,14 +122,7 @@ unsigned int CrashReportExceptionHandler::ExceptionHandlerServerException(
     }
 
     for (const auto& attachment : attachments_) {
-      FileReader file_reader;
-      if (!file_reader.Open(attachment)) {
-        LOG(ERROR) << "attachment " << attachment
-                   << " couldn't be opened, skipping";
-        continue;
-      }
-
-      base::FilePath filename = attachment.BaseName();
+      base::FilePath filename = attachment.GetPath().BaseName();
       FileWriter* file_writer =
           new_report->AddAttachment(base::WideToUTF8(filename.value()));
       if (file_writer == nullptr) {
@@ -134,7 +131,18 @@ unsigned int CrashReportExceptionHandler::ExceptionHandlerServerException(
         continue;
       }
 
-      CopyFileContent(&file_reader, file_writer);
+      if (attachment.HasBytes()) {
+        const std::vector<uint8_t>& bytes = attachment.GetBytes();
+        file_writer->Write(bytes.data(), bytes.size() * sizeof(uint8_t));
+      } else {
+        FileReader file_reader;
+        if (!file_reader.Open(attachment.GetPath())) {
+          LOG(ERROR) << "attachment " << attachment.GetPath().value().c_str()
+                     << " couldn't be opened, skipping";
+          continue;
+        }
+        CopyFileContent(&file_reader, file_writer);
+      }
     }
 
     if (screenshot_ && !screenshot_->empty()) {
@@ -176,20 +184,26 @@ unsigned int CrashReportExceptionHandler::ExceptionHandlerServerException(
 }
 
 void CrashReportExceptionHandler::ExceptionHandlerServerAttachmentAdded(
-    const base::FilePath& attachment) {
+    const Attachment& attachment) {
   auto it = std::find(attachments_.begin(), attachments_.end(), attachment);
   if (it != attachments_.end()) {
-    LOG(WARNING) << "ignoring duplicate attachment " << attachment;
+    LOG(WARNING) << "ignoring duplicate attachment "
+                 << attachment.GetUuid().ToString() << " ("
+                 << attachment.GetPath() << ")";
     return;
   }
   attachments_.push_back(attachment);
 }
 
 void CrashReportExceptionHandler::ExceptionHandlerServerAttachmentRemoved(
-    const base::FilePath& attachment) {
-  auto it = std::find(attachments_.begin(), attachments_.end(), attachment);
+    const UUID& uuid) {
+  auto it = std::find_if(attachments_.begin(),
+                         attachments_.end(),
+                         [uuid](const Attachment& attachment) {
+                           return attachment.GetUuid() == uuid;
+                         });
   if (it == attachments_.end()) {
-    LOG(WARNING) << "ignoring non-existent attachment " << attachment;
+    LOG(WARNING) << "ignoring non-existent attachment " << uuid.ToString();
     return;
   }
   attachments_.erase(it);

--- a/handler/win/crash_report_exception_handler.h
+++ b/handler/win/crash_report_exception_handler.h
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "handler/user_stream_data_source.h"
+#include "util/misc/attachment.h"
 #include "util/win/exception_handler_server.h"
 
 namespace crashpad {
@@ -79,16 +80,14 @@ class CrashReportExceptionHandler final
       HANDLE process,
       WinVMAddress exception_information_address,
       WinVMAddress debug_critical_section_address) override;
-  void ExceptionHandlerServerAttachmentAdded(
-      const base::FilePath& attachment) override;
-  void ExceptionHandlerServerAttachmentRemoved(
-      const base::FilePath& attachment) override;
+  void ExceptionHandlerServerAttachmentAdded(const Attachment& attachment) override;
+  void ExceptionHandlerServerAttachmentRemoved(const UUID& uuid) override;
 
  private:
   CrashReportDatabase* database_;  // weak
   CrashReportUploadThread* upload_thread_;  // weak
   const std::map<std::string, std::string>* process_annotations_;  // weak
-  std::vector<base::FilePath> attachments_;
+  std::vector<Attachment> attachments_;
   const base::FilePath* screenshot_;  // weak
   const bool wait_for_upload_;
   const UserStreamDataSources* user_stream_data_sources_;  // weak

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(crashpad_util STATIC
     misc/address_types.h
     misc/arraysize.h
     misc/as_underlying_type.h
+    misc/attachment.cc
+    misc/attachment.h
     misc/capture_context.h
     misc/clock.h
     misc/elf_note_types.h

--- a/util/linux/exception_handler_client.cc
+++ b/util/linux/exception_handler_client.cc
@@ -225,22 +225,31 @@ int ExceptionHandlerClient::WaitForCrashDumpComplete() {
   return errno;
 }
 
-void ExceptionHandlerClient::AddAttachment(const base::FilePath& attachment) {
+void ExceptionHandlerClient::AddAttachment(const Attachment& attachment) {
   ExceptionHandlerProtocol::ClientToServerMessage message;
   message.type =
       ExceptionHandlerProtocol::ClientToServerMessage::kTypeAddAttachment;
-  snprintf(
-      message.attachment_info.path, PATH_MAX, "%s", attachment.value().c_str());
+  snprintf(message.attachment_info.path,
+           PATH_MAX,
+           "%s",
+           attachment.GetPath().value().c_str());
+  message.attachment_info.uuid = attachment.GetUuid();
+  message.attachment_info.bytes = attachment.GetBytes().size();
+
   UnixCredentialSocket::SendMsg(server_sock_, &message, sizeof(message));
+
+  if (attachment.HasBytes()) {
+    const std::vector<uint8_t>& bytes = attachment.GetBytes();
+    UnixCredentialSocket::SendMsg(
+        server_sock_, bytes.data(), bytes.size() * sizeof(uint8_t));
+  }
 }
 
-void ExceptionHandlerClient::RemoveAttachment(
-    const base::FilePath& attachment) {
+void ExceptionHandlerClient::RemoveAttachment(const UUID& uuid) {
   ExceptionHandlerProtocol::ClientToServerMessage message;
   message.type =
       ExceptionHandlerProtocol::ClientToServerMessage::kTypeRemoveAttachment;
-  snprintf(
-      message.attachment_info.path, PATH_MAX, "%s", attachment.value().c_str());
+  message.attachment_info.uuid = uuid;
   UnixCredentialSocket::SendMsg(server_sock_, &message, sizeof(message));
 }
 

--- a/util/linux/exception_handler_client.h
+++ b/util/linux/exception_handler_client.h
@@ -19,6 +19,7 @@
 #include <sys/types.h>
 
 #include "util/linux/exception_handler_protocol.h"
+#include "util/misc/attachment.h"
 
 namespace crashpad {
 
@@ -69,10 +70,10 @@ class ExceptionHandlerClient {
   void SetCanSetPtracer(bool can_set_ptracer);
 
   //! \brief Adds an attachment to the crash report.
-  void AddAttachment(const base::FilePath& attachment);
+  void AddAttachment(const Attachment& attachment);
 
   //! \brief Removes an attachment from the crash report.
-  void RemoveAttachment(const base::FilePath& attachment);
+  void RemoveAttachment(const UUID& uuid);
 
  private:
   int SendCrashDumpRequest(

--- a/util/linux/exception_handler_protocol.h
+++ b/util/linux/exception_handler_protocol.h
@@ -24,6 +24,7 @@
 #include "build/build_config.h"
 #include "util/file/file_io.h"
 #include "util/misc/address_types.h"
+#include "util/misc/uuid.h"
 
 namespace crashpad {
 
@@ -62,6 +63,8 @@ class ExceptionHandlerProtocol {
 
   struct AttachmentInformation {
     char path[PATH_MAX];
+    UUID uuid;
+    size_t bytes;
   };
 
   //! \brief The signal used to indicate a crash dump is complete.

--- a/util/misc/attachment.cc
+++ b/util/misc/attachment.cc
@@ -1,0 +1,40 @@
+// Copyright 2014 The Crashpad Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/misc/attachment.h"
+
+namespace crashpad {
+
+Attachment::Attachment(const base::FilePath& path, const UUID& uuid)
+    : uuid_(uuid), path_(path) {}
+
+Attachment::Attachment(const std::vector<uint8_t>& bytes,
+                       const base::FilePath& filename,
+                       const UUID& uuid)
+    : uuid_(uuid), path_(filename), bytes_(bytes) {}
+
+Attachment Attachment::FromPath(const base::FilePath& path) {
+  UUID uuid;
+  uuid.InitializeWithNew();
+  return Attachment(path, uuid);
+}
+
+Attachment Attachment::FromBytes(const std::vector<uint8_t>& bytes,
+                                 const base::FilePath& filename) {
+  UUID uuid;
+  uuid.InitializeWithNew();
+  return Attachment(bytes, filename, uuid);
+}
+
+}  // namespace crashpad

--- a/util/misc/attachment.h
+++ b/util/misc/attachment.h
@@ -1,0 +1,54 @@
+// Copyright 2014 The Crashpad Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CRASHPAD_UTIL_MISC_ATTACHMENT_H_
+#define CRASHPAD_UTIL_MISC_ATTACHMENT_H_
+
+#include <vector>
+
+#include "base/files/file_path.h"
+#include "util/misc/uuid.h"
+
+namespace crashpad {
+
+class Attachment {
+ public:
+  Attachment(const base::FilePath& path, const UUID& uuid);
+  Attachment(const std::vector<uint8_t>& bytes,
+             const base::FilePath& filename,
+             const UUID& uuid);
+
+  static Attachment FromPath(const base::FilePath& path);
+  static Attachment FromBytes(const std::vector<uint8_t>& bytes,
+                              const base::FilePath& filename);
+
+  bool operator==(const Attachment& other) const {
+    return uuid_ == other.uuid_;
+  }
+
+  UUID GetUuid() const { return uuid_; }
+  const base::FilePath& GetPath() const { return path_; }
+
+  bool HasBytes() const { return !bytes_.empty(); }
+  const std::vector<uint8_t>& GetBytes() const { return bytes_; }
+
+ private:
+  UUID uuid_;
+  base::FilePath path_;
+  std::vector<uint8_t> bytes_;
+};
+
+}  // namespace crashpad
+
+#endif  // CRASHPAD_UTIL_MISC_ATTACHMENT_H_

--- a/util/win/exception_handler_server.cc
+++ b/util/win/exception_handler_server.cc
@@ -457,18 +457,33 @@ bool ExceptionHandlerServer::ServiceClientConnection(
 
     case ClientToServerMessage::kAddAttachment: {
       ServerToClientMessage shutdown_response = {};
-      service_context.delegate()->ExceptionHandlerServerAttachmentAdded(
-          base::FilePath(message.attachment.path));
       LoggingWriteFile(service_context.pipe(),
                        &shutdown_response,
                        sizeof(shutdown_response));
+      if (message.attachment.bytes == 0) {
+        service_context.delegate()->ExceptionHandlerServerAttachmentAdded(
+            Attachment(base::FilePath(message.attachment.path), 
+                       message.attachment.uuid));
+      } else {
+        std::vector<uint8_t> bytes(message.attachment.bytes);
+        if (!LoggingReadFileExactly(
+                service_context.pipe(), bytes.data(), bytes.size())) {
+          PLOG(ERROR) << "Failed to receive attachment ("
+                      << message.attachment.bytes << " bytes)";
+        } else {
+          service_context.delegate()->ExceptionHandlerServerAttachmentAdded(
+              Attachment(bytes,
+                         base::FilePath(message.attachment.path),
+                         message.attachment.uuid));
+        }
+      }
       return false;
     }
 
     case ClientToServerMessage::kRemoveAttachment: {
       ServerToClientMessage shutdown_response = {};
       service_context.delegate()->ExceptionHandlerServerAttachmentRemoved(
-          base::FilePath(message.attachment.path));
+          message.attachment.uuid);
       LoggingWriteFile(service_context.pipe(),
                        &shutdown_response,
                        sizeof(shutdown_response));

--- a/util/win/exception_handler_server.h
+++ b/util/win/exception_handler_server.h
@@ -20,6 +20,7 @@
 
 #include "base/synchronization/lock.h"
 #include "util/file/file_io.h"
+#include "util/misc/attachment.h"
 #include "util/win/address_types.h"
 #include "util/win/initial_client_data.h"
 #include "util/win/scoped_handle.h"
@@ -61,16 +62,14 @@ class ExceptionHandlerServer {
     //! \brief Called when the server has received a request to add an
     //! attachment.
     //!
-    //! \param[in] attachment The path of the attachment.
-    virtual void ExceptionHandlerServerAttachmentAdded(
-        const base::FilePath& attachment) = 0;
+    //! \param[in] attachment The attachment.
+    virtual void ExceptionHandlerServerAttachmentAdded(const Attachment& attachment) = 0;
 
     //! \brief Called when the server has received a request to remove an
     //! attachment.
     //!
-    //! \param[in] attachment The path of the attachment.
-    virtual void ExceptionHandlerServerAttachmentRemoved(
-        const base::FilePath& attachment) = 0;
+    //! \param[in] uuid The uuid of the attachment.
+    virtual void ExceptionHandlerServerAttachmentRemoved(const UUID& uuid) = 0;
 
    protected:
     ~Delegate();

--- a/util/win/registration_protocol_win.cc
+++ b/util/win/registration_protocol_win.cc
@@ -75,6 +75,13 @@ void* GetSecurityDescriptorWithUser(const wchar_t* sddl_string, size_t* size) {
 bool SendToCrashHandlerServer(const std::wstring& pipe_name,
                               const ClientToServerMessage& message,
                               ServerToClientMessage* response) {
+  return SendToCrashHandlerServerEx(pipe_name, message, nullptr, 0, response);
+}
+
+bool SendToCrashHandlerServerEx(const std::wstring& pipe_name,
+                                const ClientToServerMessage& message,
+                                const void* payload, size_t payload_size,
+                                ServerToClientMessage* response) {
   // Retry CreateFile() in a loop. If the handler isn’t actively waiting in
   // ConnectNamedPipe() on a pipe instance because it’s busy doing something
   // else, CreateFile() will fail with ERROR_PIPE_BUSY. WaitNamedPipe() waits
@@ -137,6 +144,14 @@ bool SendToCrashHandlerServer(const std::wstring& pipe_name,
                  << ", observed " << bytes_read;
       return false;
     }
+
+    if (payload) {
+      if (!WriteFile(pipe.get(), payload, static_cast<DWORD>(payload_size))) {
+        PLOG(ERROR) << "WriteFile: payload";
+        return false;
+      }
+    }
+
     return true;
   }
 }

--- a/util/win/registration_protocol_win.h
+++ b/util/win/registration_protocol_win.h
@@ -35,6 +35,11 @@ namespace crashpad {
 bool SendToCrashHandlerServer(const std::wstring& pipe_name,
                               const ClientToServerMessage& message,
                               ServerToClientMessage* response);
+bool SendToCrashHandlerServerEx(const std::wstring& pipe_name,
+                                const ClientToServerMessage& message,
+                                const void* payload,
+                                size_t payload_size,
+                                ServerToClientMessage* response);
 
 //! \brief Wraps CreateNamedPipe() to create a single named pipe instance.
 //!

--- a/util/win/registration_protocol_win_structs.h
+++ b/util/win/registration_protocol_win_structs.h
@@ -19,6 +19,7 @@
 #include <stdint.h>
 
 #include "util/win/address_types.h"
+#include "util/misc/uuid.h"
 
 namespace crashpad {
 
@@ -120,6 +121,10 @@ struct ShutdownRequest {
 struct AttachmentRequest {
   //! \brief The path of the attachment.
   wchar_t path[MAX_PATH];
+  //! \brief The size of a memory attachment, in bytes.
+  size_t bytes;
+  //! \brief The UUID of the attachment.
+  UUID uuid;
 };
 
 //! \brief The message passed from client to server by


### PR DESCRIPTION
This PR adds Crashpad-side support for:
- https://github.com/getsentry/sentry-native/pull/1275

The existing IPC uses fixed-size structs over named pipes on Windows and Unix domain sockets on Linux. When attaching arbitrary sequences of bytes, the expected size is sent in the `kAddAttachment` message, and the respective bytes are sent as a separate trailing payload message. A UUID identifies each attachment, to make it possible to remove them later.