### PR TITLE
[crashpad] Missing upstream includes fix for handler/win/wer/crashpad_wer.cc

### DIFF
--- a/handler/win/wer/crashpad_wer.cc
+++ b/handler/win/wer/crashpad_wer.cc
@@ -20,6 +20,7 @@
 #include "util/misc/address_types.h"
 #include "util/win/registration_protocol_win_structs.h"
 
+#include <stddef.h>
 #include <Windows.h>
 #include <werapi.h>
 


### PR DESCRIPTION
Looks like this commit https://github.com/chromium/crashpad/commit/3f1b84197b68e2fa334386870f740845c433d586 hasn't been merged here (and we just hit the issue when attempting to update our builder config).