### PR TITLE
fix: hide the Objective-C ARC compile options in the interface library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,14 @@ if(LINUX)
     )
 endif()
 
+if(APPLE)
+    target_compile_options(crashpad_interface INTERFACE
+        "-fobjc-arc"
+        "-fno-objc-arc-exceptions"
+        "-Wno-deprecated-declarations"
+    )
+endif()
+
 add_library(crashpad::interface ALIAS crashpad_interface)
 
 add_subdirectory(compat)

--- a/third_party/mini_chromium/CMakeLists.txt
+++ b/third_party/mini_chromium/CMakeLists.txt
@@ -145,12 +145,6 @@ else()
     )
 endif()
 
-if(APPLE)
-    target_compile_options(mini_chromium
-        PUBLIC "-fobjc-arc" "-fno-objc-arc-exceptions"
-        PRIVATE "-Wno-deprecated-declarations"
-    )
-endif()
 if(APPLE AND NOT IOS)
     target_link_libraries(mini_chromium PUBLIC
         "-framework ApplicationServices"

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -529,8 +529,6 @@ if(APPLE)
             "-framework UIKit"
         )
     endif()
-
-    target_compile_options(crashpad_util PRIVATE "-Wno-deprecated-declarations")
 endif()
 
 if(LINUX)


### PR DESCRIPTION
Raised here: https://github.com/getsentry/sentry-native/issues/1374

The Objective-C ARC compile options were incorrectly specified as `PUBLIC` and thus propagate indiscriminately into any parent target linkage. We can move them to the `crashpad_interface` target, which is only linked privately into any other targets of the `crashpad` build and thus will never escape the `crashpad` project.