### PR TITLE
fix(win): remove `MAX_PATH` dependency

### DIFF
--- a/client/crashpad_client_win.cc
+++ b/client/crashpad_client_win.cc
@@ -1205,21 +1205,19 @@ void CrashpadClient::SetFirstChanceExceptionHandler(
 }
 
 void CrashpadClient::AddAttachment(const base::FilePath& attachment) {
-  ClientToServerMessage message = {};
-  message.type = ClientToServerMessage::kAddAttachment;
-  swprintf_s(
-      message.attachment.path, MAX_PATH, L"%ls", attachment.value().c_str());
   ServerToClientMessage response = {};
-  SendToCrashHandlerServer(ipc_pipe_, message, &response);
+  SendAttachmentToCrashHandlerServer(ipc_pipe_,
+                                     ClientToServerMessage::kAddAttachmentV2,
+                                     attachment.value(),
+                                     &response);
 }
 
 void CrashpadClient::RemoveAttachment(const base::FilePath& attachment) {
-  ClientToServerMessage message = {};
-  message.type = ClientToServerMessage::kRemoveAttachment;
-  swprintf_s(
-      message.attachment.path, MAX_PATH, L"%ls", attachment.value().c_str());
   ServerToClientMessage response = {};
-  SendToCrashHandlerServer(ipc_pipe_, message, &response);
+  SendAttachmentToCrashHandlerServer(ipc_pipe_,
+                                     ClientToServerMessage::kRemoveAttachmentV2,
+                                     attachment.value(),
+                                     &response);
 }
 
 }  // namespace crashpad

--- a/util/win/exception_handler_server.cc
+++ b/util/win/exception_handler_server.cc
@@ -295,9 +295,14 @@ void ExceptionHandlerServer::InitializeWithInheritedDataForInitialClient(
 
   first_pipe_instance_.reset(initial_client_data.first_pipe_instance());
 
-  // TODO(scottmg): Vista+. Might need to pass through or possibly find an Nt*.
-  auto data = base::HeapArray<uint8_t>::Uninit(sizeof(wchar_t) * _MAX_PATH +
-                                               sizeof(FILE_NAME_INFO));
+  // Allocate buffer for FILE_NAME_INFO with maximum pipe name length.
+  // According to Windows documentation, pipe name strings are limited to 256
+  // characters: https://learn.microsoft.com/en-us/windows/win32/ipc/pipe-names
+  // FILE_NAME_INFO has a flexible array member (FileName) and provides an
+  // explicit FileNameLength field, so no null terminator is needed.
+  constexpr size_t kMaxPipeNameChars = 256;
+  auto data = base::HeapArray<uint8_t>::Uninit(
+      sizeof(FILE_NAME_INFO) + sizeof(wchar_t) * kMaxPipeNameChars);
   if (!GetFileInformationByHandleEx(first_pipe_instance_.get(),
                                     FileNameInfo,
                                     data.data(),
@@ -414,6 +419,60 @@ void ExceptionHandlerServer::Stop() {
   PostQueuedCompletionStatus(port_.get(), 0, 0, nullptr);
 }
 
+static void HandleAddAttachmentV2(
+    const internal::PipeServiceContext& service_context,
+    const ClientToServerMessage& message) {
+  const uint32_t path_length_bytes = message.attachment_v2.path_length_bytes;
+
+  if (path_length_bytes == 0 || path_length_bytes > kMaxPathBytes) {
+    LOG(ERROR) << "Invalid path length: " << path_length_bytes;
+    return;
+  }
+
+  auto path_buffer =
+      base::HeapArray<wchar_t>::Uninit(path_length_bytes / sizeof(wchar_t));
+
+  if (!LoggingReadFileExactly(
+          service_context.pipe(), path_buffer.data(), path_length_bytes)) {
+    LOG(ERROR) << "Failed to read attachment path";
+    return;
+  }
+
+  path_buffer[path_buffer.size() - 1] = L'\0';
+
+  ServerToClientMessage response = {};
+  service_context.delegate()->ExceptionHandlerServerAttachmentAdded(
+      base::FilePath(std::wstring(path_buffer.data())));
+  LoggingWriteFile(service_context.pipe(), &response, sizeof(response));
+}
+
+static void HandleRemoveAttachmentV2(
+    const internal::PipeServiceContext& service_context,
+    const ClientToServerMessage& message) {
+  const uint32_t path_length_bytes = message.attachment_v2.path_length_bytes;
+
+  if (path_length_bytes == 0 || path_length_bytes > kMaxPathBytes) {
+    LOG(ERROR) << "Invalid path length: " << path_length_bytes;
+    return;
+  }
+
+  auto path_buffer =
+      base::HeapArray<wchar_t>::Uninit(path_length_bytes / sizeof(wchar_t));
+
+  if (!LoggingReadFileExactly(
+          service_context.pipe(), path_buffer.data(), path_length_bytes)) {
+    LOG(ERROR) << "Failed to read attachment path";
+    return;
+  }
+
+  path_buffer[path_buffer.size() - 1] = L'\0';
+
+  ServerToClientMessage response = {};
+  service_context.delegate()->ExceptionHandlerServerAttachmentRemoved(
+      base::FilePath(std::wstring(path_buffer.data())));
+  LoggingWriteFile(service_context.pipe(), &response, sizeof(response));
+}
+
 // This function must be called with service_context.pipe() already connected to
 // a client pipe. It exchanges data with the client and adds a ClientData record
 // to service_context->clients().
@@ -472,6 +531,16 @@ bool ExceptionHandlerServer::ServiceClientConnection(
       LoggingWriteFile(service_context.pipe(),
                        &shutdown_response,
                        sizeof(shutdown_response));
+      return false;
+    }
+
+    case ClientToServerMessage::kAddAttachmentV2: {
+      HandleAddAttachmentV2(service_context, message);
+      return false;
+    }
+
+    case ClientToServerMessage::kRemoveAttachmentV2: {
+      HandleRemoveAttachmentV2(service_context, message);
       return false;
     }
 

--- a/util/win/exception_handler_server.cc
+++ b/util/win/exception_handler_server.cc
@@ -429,6 +429,11 @@ static void HandleAddAttachmentV2(
     return;
   }
 
+  if (path_length_bytes % sizeof(wchar_t) != 0) {
+    LOG(ERROR) << "Invalid path length: not aligned to wchar_t boundary";
+    return;
+  }
+
   auto path_buffer =
       base::HeapArray<wchar_t>::Uninit(path_length_bytes / sizeof(wchar_t));
 
@@ -453,6 +458,11 @@ static void HandleRemoveAttachmentV2(
 
   if (path_length_bytes == 0 || path_length_bytes > kMaxPathBytes) {
     LOG(ERROR) << "Invalid path length: " << path_length_bytes;
+    return;
+  }
+
+  if (path_length_bytes % sizeof(wchar_t) != 0) {
+    LOG(ERROR) << "Invalid path length: not aligned to wchar_t boundary";
     return;
   }
 

--- a/util/win/registration_protocol_win.h
+++ b/util/win/registration_protocol_win.h
@@ -36,6 +36,24 @@ bool SendToCrashHandlerServer(const std::wstring& pipe_name,
                               const ClientToServerMessage& message,
                               ServerToClientMessage* response);
 
+//! \brief Connect over the given \a pipe_name, passing a variable-length
+//!     attachment message to the server.
+//!
+//! This is used for kAddAttachmentV2 and kRemoveAttachmentV2 message types
+//! which support paths longer than MAX_PATH.
+//!
+//! \param[in] pipe_name The name of the pipe to connect to.
+//! \param[in] message_type Either kAddAttachmentV2 or kRemoveAttachmentV2.
+//! \param[in] path The attachment path to send.
+//! \param[out] response The server's response.
+//!
+//! \return `true` on success, `false` on failure with a message logged.
+bool SendAttachmentToCrashHandlerServer(
+    const std::wstring& pipe_name,
+    ClientToServerMessage::Type message_type,
+    const std::wstring& path,
+    ServerToClientMessage* response);
+
 //! \brief Wraps CreateNamedPipe() to create a single named pipe instance.
 //!
 //! \param[in] pipe_name The name to use for the pipe.

--- a/util/win/registration_protocol_win_structs.h
+++ b/util/win/registration_protocol_win_structs.h
@@ -116,11 +116,25 @@ struct ShutdownRequest {
   uint64_t token;
 };
 
-//! \brief A file attachment request.
+//! \brief A file attachment request (legacy, limited to MAX_PATH).
 struct AttachmentRequest {
   //! \brief The path of the attachment.
   wchar_t path[MAX_PATH];
 };
+
+//! \brief A variable-length file attachment request header.
+//!
+//! For kAddAttachmentV2 and kRemoveAttachmentV2, the message consists of
+//! a ClientToServerMessage with this header in the union, followed by
+//! path_length_bytes of wchar_t data containing the null-terminated path.
+struct AttachmentRequestV2 {
+  //! \brief Length of the path in bytes, including null terminator.
+  uint32_t path_length_bytes;
+};
+
+//! follow the maximum path length documented here:
+//! https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+constexpr uint32_t kMaxPathBytes = 32768 * sizeof(wchar_t);
 
 //! \brief The message passed from client to server by
 //!     SendToCrashHandlerServer().
@@ -133,22 +147,29 @@ struct ClientToServerMessage {
     //! \brief For ShutdownRequest.
     kShutdown,
 
-    //! \brief For AttachmentRequest.
+    //! \brief For AttachmentRequest (legacy, MAX_PATH limited).
     kAddAttachment,
 
-    //! \brief For AttachmentRequest.
+    //! \brief For AttachmentRequest (legacy, MAX_PATH limited).
     kRemoveAttachment,
 
     //! \brief An empty message sent by the initial client in asynchronous mode.
     //!     No data is required, this just confirms that the server is ready to
     //!     accept client registrations.
     kPing,
+
+    //! \brief For AttachmentRequestV2 (variable-length paths).
+    kAddAttachmentV2,
+
+    //! \brief For AttachmentRequestV2 (variable-length paths).
+    kRemoveAttachmentV2,
   } type;
 
   union {
     RegistrationRequest registration;
     ShutdownRequest shutdown;
     AttachmentRequest attachment;
+    AttachmentRequestV2 attachment_v2;
   };
 };
 


### PR DESCRIPTION
This is meant to be merged and released with https://github.com/getsentry/sentry-native/pull/1413.

It removes `MAX_PATH` dependencies where it makes sense (similar in intent to https://github.com/getsentry/breakpad/pull/43). In particular, `MAX_PATH` will no longer be used for

* attachment paths
* retrieving the module filename via `GetModuleFileName()`
* retrieving the pipename via `GetFileInformationByHandleEx()`

While the latter two are only changes in terms of heap buffer handling, the first item required an adaptation of the IPC protocol. There were two options:

* adapt the entire IPC protocol to support dynamically sized bytestreams (currently, only fixed-sized messages are supported)
* add only a special handler for dynamically sized attachment paths on the client and serve

I chose the latter option because it introduces the least amount of change with respect to upstream maintenance.