### PR TITLE
fix: add GNU stack note to crashpad_info_note.S

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,10 +24,10 @@ jobs:
             platform: ubuntu-22.04
             CC: gcc
             CXX: g++
-          - name: Ubuntu (GCC 9.5.0)
+          - name: Ubuntu (GCC 10.5.0)
             platform: ubuntu-22.04
-            CC: gcc-9
-            CXX: g++-9
+            CC: gcc-10
+            CXX: g++-10
           - name: Ubuntu (clang 18.1.3)
             platform: ubuntu-24.04
             CC: clang

--- a/client/crashpad_info_note.S
+++ b/client/crashpad_info_note.S
@@ -66,3 +66,4 @@ CRASHPAD_NOTE_REFERENCE:
   // linking Crashpad. The subtraction from |name| is a convenience to allow the
   // value to be computed statically.
   .quad name - CRASHPAD_NOTE
+  .section .note.GNU-stack,"",@progbits


### PR DESCRIPTION
Without a GNU-Stack note, the stack will be set to executable. For many build setups, this is currently only a warning, but we already have concrete examples where this breaks: https://github.com/getsentry/sentry-native/issues/1442

This will be pulled into the parent via https://github.com/getsentry/sentry-native/pull/1446