### PR TITLE
chore(readme): add C++ standard requirement being C++17

### DIFF
--- a/README.getsentry.md
+++ b/README.getsentry.md
@@ -7,6 +7,7 @@
 - Build System Changes Listed Below.
 - MinGW build support.
 - Screenshot support for Windows.
+- C++17 standard requirement (upstream uses C++20 or newer).
 
 # Build System Changes
 


### PR DESCRIPTION
Added a bullet point on the sentry fork requiring c++17 instead of c++20.