### PR TITLE
fix: namespace mpack to avoid ODR violation

### DIFF
--- a/third_party/mpack/README.crashpad
+++ b/third_party/mpack/README.crashpad
@@ -11,4 +11,5 @@ Description:
 A C encoder/decoder for the MessagePack serialization format
 
 Local Modifications:
-Renamed mpack.c to mpack.cc.
+- Renamed mpack.c to mpack.cc.
+- Wrapped in crashpad namespace.

--- a/third_party/mpack/mpack.cc
+++ b/third_party/mpack/mpack.cc
@@ -34,6 +34,7 @@
 
 #include "mpack.h"
 
+namespace crashpad {
 
 /* mpack/mpack-platform.c.c */
 
@@ -7302,3 +7303,5 @@ mpack_node_t mpack_node_map_value_at(mpack_node_t node, size_t index) {
 #endif
 
 MPACK_SILENCE_WARNINGS_END
+
+}  // namespace crashpad

--- a/third_party/mpack/mpack.h
+++ b/third_party/mpack/mpack.h
@@ -1066,8 +1066,8 @@ void mpack_assert_fail(const char* message);
  */
 
 #ifdef __cplusplus
-    #define MPACK_EXTERN_C_BEGIN extern "C" {
-    #define MPACK_EXTERN_C_END   }
+    #define MPACK_EXTERN_C_BEGIN /*nothing*/
+    #define MPACK_EXTERN_C_END   /*nothing*/
 #else
     #define MPACK_EXTERN_C_BEGIN /*nothing*/
     #define MPACK_EXTERN_C_END   /*nothing*/
@@ -1173,6 +1173,7 @@ void mpack_assert_fail(const char* message);
 
 MPACK_SILENCE_WARNINGS_BEGIN
 MPACK_EXTERN_C_BEGIN
+namespace crashpad {
 
 
 
@@ -8197,6 +8198,7 @@ bool mpack_node_map_contains_cstr(mpack_node_t node, const char* cstr);
 
 #endif
 
+}  // namespace crashpad
 MPACK_EXTERN_C_END
 MPACK_SILENCE_WARNINGS_END
 


### PR DESCRIPTION
Avoids overlapping `mpack_xxx` symbols when `crashpad_client` is linked to sentry-native:

- `vendor/mpack.c`: `libsentry.so` > `mpack.c.o`
- `external/crashpad/third_party/mpack/mpack.cc`: `libsentry.so` > `libcrashpad_client.a` > `libcrashpad_util.a` > `libcrashpad_mpack.a` > `mpack.cc.o`

P.S. For what it's worth, the same approach is used in [third_party/getopt](https://github.com/getsentry/crashpad/tree/getsentry/third_party/getopt).