### PR TITLE
feat: allow predefined report ID

### DIFF
--- a/client/client_argv_handling.cc
+++ b/client/client_argv_handling.cc
@@ -37,7 +37,8 @@ std::vector<std::string> BuildHandlerArgvStrings(
     const std::vector<std::string>& arguments,
     const std::vector<base::FilePath>& attachments,
     const base::FilePath& crash_reporter,
-    const base::FilePath& crash_envelope) {
+    const base::FilePath& crash_envelope,
+    const std::string& report_id) {
   std::vector<std::string> argv_strings(1, handler.value());
 
   for (const auto& argument : arguments) {
@@ -79,6 +80,10 @@ std::vector<std::string> BuildHandlerArgvStrings(
   if (!crash_envelope.empty()) {
     argv_strings.push_back(
         FormatArgumentString("crash-envelope", crash_envelope.value()));
+  }
+
+  if (!report_id.empty()) {
+    argv_strings.push_back(FormatArgumentString("report-id", report_id));
   }
 
   return argv_strings;

--- a/client/client_argv_handling.h
+++ b/client/client_argv_handling.h
@@ -39,7 +39,8 @@ std::vector<std::string> BuildHandlerArgvStrings(
     const std::vector<std::string>& arguments,
     const std::vector<base::FilePath>& attachments = {},
     const base::FilePath& crash_reporter = base::FilePath(),
-    const base::FilePath& crash_envelope = base::FilePath());
+    const base::FilePath& crash_envelope = base::FilePath(),
+    const std::string& report_id = std::string());
 
 //! \brief Flattens a string vector into a const char* vector suitable for use
 //!     in an exec() call.

--- a/client/crash_report_database.cc
+++ b/client/crash_report_database.cc
@@ -199,10 +199,13 @@ CrashReportDatabase::NewReport::~NewReport() = default;
 bool CrashReportDatabase::NewReport::Initialize(
     CrashReportDatabase* database,
     const base::FilePath& directory,
-    const base::FilePath::StringType& extension) {
+    const base::FilePath::StringType& extension,
+    const UUID* uuid) {
   database_ = database;
 
-  if (!uuid_.InitializeWithNew()) {
+  if (uuid && !uuid->IsZero()) {
+    uuid_ = *uuid;
+  } else if (!uuid_.InitializeWithNew()) {
     return false;
   }
 

--- a/client/crash_report_database.h
+++ b/client/crash_report_database.h
@@ -145,7 +145,8 @@ class CrashReportDatabase {
 
     bool Initialize(CrashReportDatabase* database,
                     const base::FilePath& directory,
-                    const base::FilePath::StringType& extension);
+                    const base::FilePath::StringType& extension,
+                    const UUID* uuid = nullptr);
 
     std::unique_ptr<FileWriter> writer_;
     std::unique_ptr<FileReader> reader_;
@@ -331,10 +332,12 @@ class CrashReportDatabase {
   //!
   //! \param[out] report A NewReport object containing a FileWriter with which
   //!     to write the report data. Only valid if this returns #kNoError.
+  //! \param[in] uuid Optional caller-provided UUID to use for this report. If
+  //!     null, the database generates one.
   //!
   //! \return The operation status code.
   virtual OperationStatus PrepareNewCrashReport(
-      std::unique_ptr<NewReport>* report) = 0;
+      std::unique_ptr<NewReport>* report, const UUID* uuid = nullptr) = 0;
 
   //! \brief Informs the database that a crash report has been successfully
   //!     written.

--- a/client/crash_report_database_generic.cc
+++ b/client/crash_report_database_generic.cc
@@ -176,7 +176,7 @@ class CrashReportDatabaseGeneric : public CrashReportDatabase {
   // CrashReportDatabase:
   Settings* GetSettings() override;
   OperationStatus PrepareNewCrashReport(
-      std::unique_ptr<NewReport>* report) override;
+      std::unique_ptr<NewReport>* report, const UUID* uuid) override;
   OperationStatus FinishedWritingCrashReport(std::unique_ptr<NewReport> report,
                                              UUID* uuid) override;
   OperationStatus LookUpCrashReport(const UUID& uuid, Report* report) override;
@@ -332,12 +332,15 @@ Settings* CrashReportDatabaseGeneric::GetSettings() {
 }
 
 OperationStatus CrashReportDatabaseGeneric::PrepareNewCrashReport(
-    std::unique_ptr<NewReport>* report) {
+    std::unique_ptr<NewReport>* report, const UUID* uuid) {
   INITIALIZATION_STATE_DCHECK_VALID(initialized_);
 
   auto new_report = std::make_unique<NewReport>();
   if (!new_report->Initialize(
-          this, base_dir_.Append(kNewDirectory), kCrashReportExtension)) {
+          this,
+          base_dir_.Append(kNewDirectory),
+          kCrashReportExtension,
+          uuid)) {
     return kFileSystemError;
   }
 

--- a/client/crash_report_database_mac.mm
+++ b/client/crash_report_database_mac.mm
@@ -152,7 +152,7 @@ class CrashReportDatabaseMac : public CrashReportDatabase {
   // CrashReportDatabase:
   Settings* GetSettings() override;
   OperationStatus PrepareNewCrashReport(
-      std::unique_ptr<NewReport>* report) override;
+      std::unique_ptr<NewReport>* report, const UUID* uuid) override;
   OperationStatus FinishedWritingCrashReport(std::unique_ptr<NewReport> report,
                                              UUID* uuid) override;
   OperationStatus LookUpCrashReport(const UUID& uuid, Report* report) override;
@@ -371,13 +371,14 @@ Settings* CrashReportDatabaseMac::GetSettings() {
 
 CrashReportDatabase::OperationStatus
 CrashReportDatabaseMac::PrepareNewCrashReport(
-    std::unique_ptr<NewReport>* out_report) {
+    std::unique_ptr<NewReport>* out_report, const UUID* uuid) {
   INITIALIZATION_STATE_DCHECK_VALID(initialized_);
 
   std::unique_ptr<NewReport> report(new NewReport());
   if (!report->Initialize(this,
                           base_dir_.Append(kWriteDirectory),
-                          std::string(".") + kCrashReportFileExtension)) {
+                          std::string(".") + kCrashReportFileExtension,
+                          uuid)) {
     return kFileSystemError;
   }
 

--- a/client/crash_report_database_win.cc
+++ b/client/crash_report_database_win.cc
@@ -635,7 +635,7 @@ class CrashReportDatabaseWin : public CrashReportDatabase {
   // CrashReportDatabase:
   Settings* GetSettings() override;
   OperationStatus PrepareNewCrashReport(
-      std::unique_ptr<NewReport>* report) override;
+      std::unique_ptr<NewReport>* report, const UUID* uuid) override;
   OperationStatus FinishedWritingCrashReport(std::unique_ptr<NewReport> report,
                                              UUID* uuid) override;
   OperationStatus LookUpCrashReport(const UUID& uuid, Report* report) override;
@@ -749,13 +749,14 @@ Settings* CrashReportDatabaseWin::GetSettings() {
 }
 
 OperationStatus CrashReportDatabaseWin::PrepareNewCrashReport(
-    std::unique_ptr<NewReport>* report) {
+    std::unique_ptr<NewReport>* report, const UUID* uuid) {
   INITIALIZATION_STATE_DCHECK_VALID(initialized_);
 
   std::unique_ptr<NewReport> new_report(new NewReport());
   if (!new_report->Initialize(this,
                               base_dir_.Append(kReportsDirectory),
-                              std::wstring(L".") + kCrashReportFileExtension)) {
+                              std::wstring(L".") + kCrashReportFileExtension,
+                              uuid)) {
     return kFileSystemError;
   }
 

--- a/client/crashpad_client.h
+++ b/client/crashpad_client.h
@@ -129,6 +129,8 @@ class CrashpadClient {
   //!     executable that will be executed after a crash has been captured.
   //! \param[in] crash_envelope The path to a crash report envelope that will be
   //!     filled up and passed as an argument to the crash reporter.
+  //! \param[in] report_id A UUID string to use as the report identifier instead
+  //!     of generating a random one.
   //!
   //! \return `true` on success, `false` on failure with a message logged.
   bool StartHandler(const base::FilePath& handler,
@@ -144,7 +146,8 @@ class CrashpadClient {
                     const base::FilePath& screenshot = base::FilePath(),
                     bool wait_for_upload = false,
                     const base::FilePath& crash_reporter = base::FilePath(),
-                    const base::FilePath& crash_envelope = base::FilePath());
+                    const base::FilePath& crash_envelope = base::FilePath(),
+                    const std::string& report_id = std::string());
 
 #if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || \
     DOXYGEN

--- a/client/crashpad_client_linux.cc
+++ b/client/crashpad_client_linux.cc
@@ -490,7 +490,8 @@ bool CrashpadClient::StartHandler(
     const base::FilePath& screenshot,
     bool wait_for_upload,
     const base::FilePath& crash_reporter,
-    const base::FilePath& crash_envelope) {
+    const base::FilePath& crash_envelope,
+    const std::string& report_id) {
   DCHECK(!asynchronous_start);
 
   ScopedFileHandle client_sock, handler_sock;
@@ -508,7 +509,8 @@ bool CrashpadClient::StartHandler(
                                                           arguments,
                                                           attachments,
                                                           crash_reporter,
-                                                          crash_envelope);
+                                                          crash_envelope,
+                                                          report_id);
 
   argv.push_back(FormatArgumentInt("initial-client-fd", handler_sock.get()));
   argv.push_back("--shared-client-connection");

--- a/client/crashpad_client_mac.cc
+++ b/client/crashpad_client_mac.cc
@@ -141,6 +141,7 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
       const std::vector<base::FilePath>& attachments,
       const base::FilePath& crash_reporter,
       const base::FilePath& crash_envelope,
+      const std::string& report_id,
       bool restartable) {
     base::apple::ScopedMachReceiveRight receive_right(
         NewMachPort(MACH_PORT_RIGHT_RECEIVE));
@@ -184,6 +185,7 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
                      attachments,
                      crash_reporter,
                      crash_envelope,
+                     report_id,
                      std::move(receive_right),
                      handler_restarter.get(),
                      false)) {
@@ -200,7 +202,8 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
                                               arguments,
                                               attachments,
                                               crash_reporter,
-                                              crash_envelope)) {
+                                              crash_envelope,
+                                              report_id)) {
       // The thread owns the object now.
       std::ignore = handler_restarter.release();
     }
@@ -239,6 +242,7 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
                 attachments_,
                 crash_reporter_,
                 crash_envelope_,
+                report_id_,
                 base::apple::ScopedMachReceiveRight(rights),
                 this,
                 true);
@@ -258,6 +262,7 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
         attachments_(),
         crash_reporter_(),
         crash_envelope_(),
+        report_id_(),
         notify_port_(NewMachPort(MACH_PORT_RIGHT_RECEIVE)),
         last_start_time_(0) {}
 
@@ -290,6 +295,7 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
                           const std::vector<base::FilePath>& attachments,
                           const base::FilePath& crash_reporter,
                           const base::FilePath& crash_envelope,
+                          const std::string& report_id,
                           base::apple::ScopedMachReceiveRight receive_right,
                           HandlerStarter* handler_restarter,
                           bool restart) {
@@ -387,6 +393,10 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
           FormatArgumentString("crash-envelope", crash_envelope.value()));
     }
 
+    if (!report_id.empty()) {
+      argv.push_back(FormatArgumentString("report-id", report_id));
+    }
+
     argv.push_back(FormatArgumentInt("handshake-fd", server_write_fd.get()));
 
     // When restarting, reset the system default crash handler first. Otherwise,
@@ -426,7 +436,8 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
                           const std::vector<std::string>& arguments,
                           const std::vector<base::FilePath>& attachments,
                           const base::FilePath& crash_reporter,
-                          const base::FilePath& crash_envelope) {
+                          const base::FilePath& crash_envelope,
+                          const std::string& report_id) {
     handler_ = handler;
     database_ = database;
     metrics_dir_ = metrics_dir;
@@ -437,6 +448,7 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
     attachments_ = attachments;
     crash_reporter_ = crash_reporter;
     crash_envelope_ = crash_envelope;
+    report_id_ = report_id;
 
     pthread_attr_t pthread_attr;
     errno = pthread_attr_init(&pthread_attr);
@@ -493,6 +505,7 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
   std::vector<base::FilePath> attachments_;
   base::FilePath crash_reporter_;
   base::FilePath crash_envelope_;
+  std::string report_id_;
   base::apple::ScopedMachReceiveRight notify_port_;
   uint64_t last_start_time_;
 };
@@ -519,7 +532,8 @@ bool CrashpadClient::StartHandler(
     const base::FilePath& screenshot,
     bool wait_for_upload,
     const base::FilePath& crash_reporter,
-    const base::FilePath& crash_envelope) {
+    const base::FilePath& crash_envelope,
+    const std::string& report_id) {
   (void) wait_for_upload; // unused in mac (for now)
 
   // The “restartable” behavior can only be selected on OS X 10.10 and later. In
@@ -536,6 +550,7 @@ bool CrashpadClient::StartHandler(
       attachments,
       crash_reporter,
       crash_envelope,
+      report_id,
       restartable && (__MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_10 ||
                       MacOSVersionNumber() >= 10'10'00)));
   if (!exception_port.is_valid()) {

--- a/client/crashpad_client_win.cc
+++ b/client/crashpad_client_win.cc
@@ -359,6 +359,7 @@ struct BackgroundHandlerStartThreadData {
       const bool wait_for_upload,
       const base::FilePath& crash_reporter,
       const base::FilePath& crash_envelope,
+      const std::string& report_id,
       const std::wstring& ipc_pipe,
       ScopedFileHANDLE ipc_pipe_handle)
       : handler(handler),
@@ -373,6 +374,7 @@ struct BackgroundHandlerStartThreadData {
         wait_for_upload(wait_for_upload),
         crash_reporter(crash_reporter),
         crash_envelope(crash_envelope),
+        report_id(report_id),
         ipc_pipe(ipc_pipe),
         ipc_pipe_handle(std::move(ipc_pipe_handle)) {}
 
@@ -388,6 +390,7 @@ struct BackgroundHandlerStartThreadData {
   bool wait_for_upload;
   base::FilePath crash_reporter;
   base::FilePath crash_envelope;
+  std::string report_id;
   std::wstring ipc_pipe;
   ScopedFileHANDLE ipc_pipe_handle;
 };
@@ -473,6 +476,11 @@ bool StartHandlerProcess(
   if (!data->crash_envelope.empty()) {
     AppendCommandLineArgument(
         FormatArgumentString("crash-envelope", data->crash_envelope.value()),
+        &command_line);
+  }
+  if (!data->report_id.empty()) {
+    AppendCommandLineArgument(
+        FormatArgumentString("report-id", base::UTF8ToWide(data->report_id)),
         &command_line);
   }
 
@@ -674,7 +682,8 @@ bool CrashpadClient::StartHandler(
     const base::FilePath& screenshot,
     bool wait_for_upload,
     const base::FilePath& crash_reporter,
-    const base::FilePath& crash_envelope) {
+    const base::FilePath& crash_envelope,
+    const std::string& report_id) {
   DCHECK(ipc_pipe_.empty());
 
   // Both the pipe and the signalling events have to be created on the main
@@ -710,6 +719,7 @@ bool CrashpadClient::StartHandler(
                                                    wait_for_upload,
                                                    crash_reporter,
                                                    crash_envelope,
+                                                   report_id,
                                                    ipc_pipe_,
                                                    std::move(ipc_pipe_handle));
 

--- a/handler/handler_main.cc
+++ b/handler/handler_main.cc
@@ -50,6 +50,7 @@
 #include "util/misc/address_types.h"
 #include "util/misc/metrics.h"
 #include "util/misc/paths.h"
+#include "util/misc/uuid.h"
 #include "util/numeric/in_range_cast.h"
 #include "util/stdlib/map_insert.h"
 #include "util/stdlib/string_number_conversion.h"
@@ -199,6 +200,8 @@ void Usage(const base::FilePath& me) {
       // clang-format off
 "      --url=URL               send crash reports to this Breakpad server URL,\n"
 "                              only if uploads are enabled for the database\n"
+"      --report-id=UUID        use UUID as the report identifier instead of\n"
+"                              generating a random one\n"
   // clang-format on
 #if BUILDFLAG(IS_CHROMEOS)
       // clang-format off
@@ -235,6 +238,7 @@ struct Options {
   base::FilePath database;
   base::FilePath metrics_dir;
   std::vector<std::string> monitor_self_arguments;
+  UUID report_id;
 #if BUILDFLAG(IS_APPLE)
   std::string mach_service;
   int handshake_fd;
@@ -656,6 +660,7 @@ int HandlerMain(int argc,
 #endif
     kOptionCrashReporter,
     kOptionCrashEnvelope,
+    kOptionReportID,
 
     // Standard options.
     kOptionHelp = -2,
@@ -755,6 +760,7 @@ int HandlerMain(int argc,
 #endif
     {"crash-reporter", required_argument, nullptr, kOptionCrashReporter},
     {"crash-envelope", required_argument, nullptr, kOptionCrashEnvelope},
+    {"report-id", required_argument, nullptr, kOptionReportID},
     {"help", no_argument, nullptr, kOptionHelp},
     {"version", no_argument, nullptr, kOptionVersion},
     {nullptr, 0, nullptr, 0},
@@ -962,6 +968,13 @@ int HandlerMain(int argc,
             ToolSupport::CommandLineArgumentToFilePathStringType(optarg));
         break;
       }
+      case kOptionReportID: {
+        if (!options.report_id.InitializeFromString(optarg)) {
+          ToolSupport::UsageHint(me, "failed to parse --report-id");
+          return ExitFailure();
+        }
+        break;
+      }
       case kOptionHelp: {
         Usage(me);
         MetricsRecordExit(Metrics::LifetimeMilestone::kExitedEarly);
@@ -1129,7 +1142,8 @@ int HandlerMain(int argc,
         &options.attachments,
         true,
         false,
-        user_stream_sources);
+        user_stream_sources,
+        &options.report_id);
   }
 #else
   exception_handler = std::make_unique<CrashReportExceptionHandler>(
@@ -1156,6 +1170,7 @@ int HandlerMain(int argc,
 #endif
       ,&options.crash_reporter
       ,&options.crash_envelope
+      ,&options.report_id
   );
 #endif  // BUILDFLAG(IS_CHROMEOS)
 

--- a/handler/linux/crash_report_exception_handler.cc
+++ b/handler/linux/crash_report_exception_handler.cc
@@ -109,7 +109,8 @@ CrashReportExceptionHandler::CrashReportExceptionHandler(
     const UserStreamDataSources* user_stream_data_sources,
     bool wait_for_upload,
     const base::FilePath* crash_reporter,
-    const base::FilePath* crash_envelope)
+    const base::FilePath* crash_envelope,
+    const UUID* report_id)
     : database_(database),
       upload_thread_(upload_thread),
       process_annotations_(process_annotations),
@@ -119,7 +120,8 @@ CrashReportExceptionHandler::CrashReportExceptionHandler(
       user_stream_data_sources_(user_stream_data_sources),
       wait_for_upload_(wait_for_upload),
       crash_reporter_(crash_reporter),
-      crash_envelope_(crash_envelope) {
+      crash_envelope_(crash_envelope),
+      report_id_(report_id) {
   DCHECK(write_minidump_to_database_ | write_minidump_to_log_);
 }
 
@@ -241,7 +243,7 @@ bool CrashReportExceptionHandler::WriteMinidumpToDatabase(
     UUID* local_report_id) {
   std::unique_ptr<CrashReportDatabase::NewReport> new_report;
   CrashReportDatabase::OperationStatus database_status =
-      database_->PrepareNewCrashReport(&new_report);
+      database_->PrepareNewCrashReport(&new_report, report_id_);
   if (database_status != CrashReportDatabase::kNoError) {
     LOG(ERROR) << "PrepareNewCrashReport failed";
     Metrics::ExceptionCaptureResult(

--- a/handler/linux/crash_report_exception_handler.h
+++ b/handler/linux/crash_report_exception_handler.h
@@ -73,7 +73,8 @@ class CrashReportExceptionHandler : public ExceptionHandlerServer::Delegate {
       const UserStreamDataSources* user_stream_data_sources,
       bool wait_for_upload,
       const base::FilePath* crash_reporter,
-      const base::FilePath* crash_envelope);
+      const base::FilePath* crash_envelope,
+      const UUID* report_id);
 
   CrashReportExceptionHandler(const CrashReportExceptionHandler&) = delete;
   CrashReportExceptionHandler& operator=(const CrashReportExceptionHandler&) =
@@ -132,6 +133,7 @@ class CrashReportExceptionHandler : public ExceptionHandlerServer::Delegate {
   bool wait_for_upload_ = false;
   const base::FilePath* crash_reporter_;  // weak
   const base::FilePath* crash_envelope_;  // weak
+  const UUID* report_id_;  // weak
 };
 
 }  // namespace crashpad

--- a/handler/mac/crash_report_exception_handler.cc
+++ b/handler/mac/crash_report_exception_handler.cc
@@ -51,14 +51,16 @@ CrashReportExceptionHandler::CrashReportExceptionHandler(
     const std::vector<base::FilePath>* attachments,
     const UserStreamDataSources* user_stream_data_sources,
     const base::FilePath* crash_reporter,
-    const base::FilePath* crash_envelope)
+    const base::FilePath* crash_envelope,
+    const UUID* report_id)
     : database_(database),
       upload_thread_(upload_thread),
       process_annotations_(process_annotations),
       attachments_(attachments),
       user_stream_data_sources_(user_stream_data_sources),
       crash_reporter_(crash_reporter),
-      crash_envelope_(crash_envelope) {}
+      crash_envelope_(crash_envelope),
+      report_id_(report_id) {}
 
 CrashReportExceptionHandler::~CrashReportExceptionHandler() {
 }
@@ -162,7 +164,7 @@ kern_return_t CrashReportExceptionHandler::CatchMachException(
 
     std::unique_ptr<CrashReportDatabase::NewReport> new_report;
     CrashReportDatabase::OperationStatus database_status =
-        database_->PrepareNewCrashReport(&new_report);
+        database_->PrepareNewCrashReport(&new_report, report_id_);
     if (database_status != CrashReportDatabase::kNoError) {
       Metrics::ExceptionCaptureResult(
           Metrics::CaptureResult::kPrepareNewCrashReportFailed);

--- a/handler/mac/crash_report_exception_handler.h
+++ b/handler/mac/crash_report_exception_handler.h
@@ -23,6 +23,7 @@
 #include "client/crash_report_database.h"
 #include "handler/crash_report_upload_thread.h"
 #include "handler/user_stream_data_source.h"
+#include "util/misc/uuid.h"
 #include "util/mach/exc_server_variants.h"
 
 namespace crashpad {
@@ -61,7 +62,8 @@ class CrashReportExceptionHandler final
       const std::vector<base::FilePath>* attachments,
       const UserStreamDataSources* user_stream_data_sources,
       const base::FilePath* crash_reporter,
-      const base::FilePath* crash_envelope);
+      const base::FilePath* crash_envelope,
+      const UUID* report_id);
 
   CrashReportExceptionHandler(const CrashReportExceptionHandler&) = delete;
   CrashReportExceptionHandler& operator=(const CrashReportExceptionHandler&) =
@@ -97,6 +99,7 @@ class CrashReportExceptionHandler final
   const UserStreamDataSources* user_stream_data_sources_;  // weak
   const base::FilePath* crash_reporter_;  // weak
   const base::FilePath* crash_envelope_;  // weak
+  const UUID* report_id_;  // weak
 };
 
 }  // namespace crashpad

--- a/handler/win/crash_report_exception_handler.cc
+++ b/handler/win/crash_report_exception_handler.cc
@@ -43,7 +43,8 @@ CrashReportExceptionHandler::CrashReportExceptionHandler(
     const UserStreamDataSources* user_stream_data_sources,
     const bool wait_for_upload,
     const base::FilePath* crash_reporter,
-    const base::FilePath* crash_envelope)
+    const base::FilePath* crash_envelope,
+    const UUID* report_id)
     : database_(database),
       upload_thread_(upload_thread),
       process_annotations_(process_annotations),
@@ -52,6 +53,7 @@ CrashReportExceptionHandler::CrashReportExceptionHandler(
       wait_for_upload_(wait_for_upload),
       crash_reporter_(crash_reporter),
       crash_envelope_(crash_envelope),
+      report_id_(report_id),
       user_stream_data_sources_(user_stream_data_sources) {}
 
 CrashReportExceptionHandler::~CrashReportExceptionHandler() {}
@@ -99,7 +101,7 @@ unsigned int CrashReportExceptionHandler::ExceptionHandlerServerException(
 
     std::unique_ptr<CrashReportDatabase::NewReport> new_report;
     CrashReportDatabase::OperationStatus database_status =
-        database_->PrepareNewCrashReport(&new_report);
+        database_->PrepareNewCrashReport(&new_report, report_id_);
     if (database_status != CrashReportDatabase::kNoError) {
       LOG(ERROR) << "PrepareNewCrashReport failed";
       Metrics::ExceptionCaptureResult(

--- a/handler/win/crash_report_exception_handler.h
+++ b/handler/win/crash_report_exception_handler.h
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "handler/user_stream_data_source.h"
+#include "util/misc/uuid.h"
 #include "util/win/exception_handler_server.h"
 
 namespace crashpad {
@@ -64,7 +65,8 @@ class CrashReportExceptionHandler final
       const UserStreamDataSources* user_stream_data_sources,
       bool wait_for_upload,
       const base::FilePath* crash_reporter,
-      const base::FilePath* crash_envelope);
+      const base::FilePath* crash_envelope,
+      const UUID* report_id);
 
   CrashReportExceptionHandler(const CrashReportExceptionHandler&) = delete;
   CrashReportExceptionHandler& operator=(const CrashReportExceptionHandler&) =
@@ -95,6 +97,7 @@ class CrashReportExceptionHandler final
   const bool wait_for_upload_;
   const base::FilePath* crash_reporter_;  // weak
   const base::FilePath* crash_envelope_;  // weak
+  const UUID* report_id_;  // weak
   const UserStreamDataSources* user_stream_data_sources_;  // weak
 };
 

--- a/util/misc/uuid.cc
+++ b/util/misc/uuid.cc
@@ -57,6 +57,12 @@ void UUID::InitializeToZero() {
   memset(this, 0, sizeof(*this));
 }
 
+bool UUID::IsZero() const {
+  UUID zero;
+  zero.InitializeToZero();
+  return *this == zero;
+}
+
 void UUID::InitializeFromBytes(const uint8_t* bytes_ptr) {
   // TODO(crbug.com/40284755): This span construction is unsound. The caller
   // should provide a span instead of an unbounded pointer.

--- a/util/misc/uuid.h
+++ b/util/misc/uuid.h
@@ -81,6 +81,11 @@ struct UUID {
   void InitializeFromSystemUUID(const ::UUID* system_uuid);
 #endif  // BUILDFLAG(IS_WIN)
 
+  //! \brief Checks whether the %UUID is zero (all bytes are 0).
+  //!
+  //! \return `true` if the %UUID is all zeros, `false` otherwise.
+  bool IsZero() const;
+
   //! \brief Formats the %UUID per RFC 4122 §3.
   //!
   //! \return A string of the form `"00112233-4455-6677-8899-aabbccddeeff"`.


### PR DESCRIPTION
This PR adds a `--report-id=<uuid>` command-line argument to the crashpad handler to allow predefined report IDs instead of generating random IDs. With this, we can make crashpad write `<event_id>.dmp` that is easy to associate with the respective event envelope for offline caching purposes.

See also:
- https://github.com/getsentry/sentry-native/pull/1488
