### PR TITLE
chore: add `LANGUAGE ASM_MASM` property to source files

### DIFF
--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -390,6 +390,10 @@ if(WIN32)
             target_sources(crashpad_util PRIVATE
                 misc/capture_context_win_arm64.asm
             )
+            set_source_files_properties(
+                misc/capture_context_win_arm64.asm
+                PROPERTIES LANGUAGE ASM_MARMASM
+            )
         endif()
     else()
         target_sources(crashpad_util PRIVATE
@@ -397,9 +401,9 @@ if(WIN32)
             win/safe_terminate_process.asm
         )
         set_source_files_properties(
-                misc/capture_context_win.asm
-                win/safe_terminate_process.asm
-                PROPERTIES LANGUAGE ASM_MASM
+            misc/capture_context_win.asm
+            win/safe_terminate_process.asm
+            PROPERTIES LANGUAGE ASM_MASM
         )
     endif()
 endif()

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -396,6 +396,11 @@ if(WIN32)
             misc/capture_context_win.asm
             win/safe_terminate_process.asm
         )
+        set_source_files_properties(
+                misc/capture_context_win.asm
+                win/safe_terminate_process.asm
+                PROPERTIES LANGUAGE ASM_MASM
+        )
     endif()
 endif()
 


### PR DESCRIPTION
A [user reported an issue](https://github.com/getsentry/sentry-dart/issues/3322#issuecomment-3790042937) where `nasm.exe` was being used to pick up our `.asm` files, but since the files in question use `MASM` syntax this led to an error.

I suggested we could add the `LANGUAGE` property to fix (which was [confirmed by the user](https://github.com/getsentry/sentry-dart/issues/3322#issuecomment-3790042937) that this works).