### PR TITLE
fix: replace `googlesource` submodules with GitHub ones

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/getsentry/mini_chromium.git
 [submodule "third_party/zlib/zlib"]
 	path = third_party/zlib/zlib
-	url = https://chromium.googlesource.com/chromium/src/third_party/zlib
+	url = https://github.com/getsentry/chromium-zlib
 [submodule "third_party/lss/lss"]
 	path = third_party/lss/lss
-	url = https://chromium.googlesource.com/linux-syscall-support
+	url = https://github.com/getsentry/chromium-linux-syscall-support


### PR DESCRIPTION
Fixes the crashpad part of failing upstream repositories raised here: https://github.com/getsentry/sentry-native/issues/1626