### PR TITLE
feat: add --log-file and --log-level options

### DIFF
--- a/handler/handler_main.cc
+++ b/handler/handler_main.cc
@@ -224,6 +224,8 @@ void Usage(const base::FilePath& me) {
 #endif  // BUILDFLAG(IS_ANDROID)
       // clang-format off
 "      --log-file=FILE         write handler log output to FILE\n"
+"      --log-level=N           minimum log severity (-1=verbose, 0=info,\n"
+"                              1=warning, 2=error, 4=fatal)\n"
 "      --help                  display this help and exit\n"
 "      --version               output version information and exit\n",
           me.value().c_str());
@@ -572,7 +574,8 @@ class ScopedStoppable {
   std::unique_ptr<Stoppable> stoppable_;
 };
 
-void InitCrashpadLogging(const base::FilePath& log_file_path) {
+void InitCrashpadLogging(const base::FilePath& log_file_path,
+                         int min_log_level) {
   logging::LoggingSettings settings;
 #if BUILDFLAG(IS_CHROMEOS)
   settings.logging_dest = logging::LOG_TO_FILE;
@@ -588,6 +591,7 @@ void InitCrashpadLogging(const base::FilePath& log_file_path) {
     settings.logging_dest |= logging::LOG_TO_FILE;
     settings.log_file_path = log_file_path;
   }
+  settings.min_log_level = min_log_level;
   logging::InitLogging(settings);
 }
 
@@ -596,21 +600,31 @@ void InitCrashpadLogging(const base::FilePath& log_file_path) {
 int HandlerMain(int argc,
                 char* argv[],
                 const UserStreamDataSources* user_stream_sources) {
-  // Pre-scan argv for --log-file= so that log output from HandlerMain
-  // (including option-parsing errors) is captured to the file.
+  // Pre-scan argv for --log-file= and --log-level= so that log output from
+  // HandlerMain (including option-parsing errors) is captured to the file
+  // and filtered to the requested severity.
   base::FilePath log_file_path;
+  int min_log_level = logging::LOG_INFO;
   for (int i = 1; i < argc; ++i) {
+    if (!argv[i]) {
+      continue;
+    }
     static constexpr char kLogFilePrefix[] = "--log-file=";
-    if (argv[i] &&
-        strncmp(argv[i], kLogFilePrefix, sizeof(kLogFilePrefix) - 1) == 0) {
+    static constexpr char kLogLevelPrefix[] = "--log-level=";
+    if (strncmp(argv[i], kLogFilePrefix, sizeof(kLogFilePrefix) - 1) == 0) {
       log_file_path = base::FilePath(
           ToolSupport::CommandLineArgumentToFilePathStringType(
               argv[i] + sizeof(kLogFilePrefix) - 1));
-      break;
+    } else if (strncmp(argv[i], kLogLevelPrefix,
+                       sizeof(kLogLevelPrefix) - 1) == 0) {
+      int parsed;
+      if (StringToNumber(argv[i] + sizeof(kLogLevelPrefix) - 1, &parsed)) {
+        min_log_level = parsed;
+      }
     }
   }
 
-  InitCrashpadLogging(log_file_path);
+  InitCrashpadLogging(log_file_path, min_log_level);
 
   InstallCrashHandler();
   CallMetricsRecordNormalExit metrics_record_normal_exit;
@@ -682,6 +696,7 @@ int HandlerMain(int argc,
     kOptionCrashEnvelope,
     kOptionReportID,
     kOptionLogFile,
+    kOptionLogLevel,
 
     // Standard options.
     kOptionHelp = -2,
@@ -783,6 +798,7 @@ int HandlerMain(int argc,
     {"crash-envelope", required_argument, nullptr, kOptionCrashEnvelope},
     {"report-id", required_argument, nullptr, kOptionReportID},
     {"log-file", required_argument, nullptr, kOptionLogFile},
+    {"log-level", required_argument, nullptr, kOptionLogLevel},
     {"help", no_argument, nullptr, kOptionHelp},
     {"version", no_argument, nullptr, kOptionVersion},
     {nullptr, 0, nullptr, 0},
@@ -997,7 +1013,8 @@ int HandlerMain(int argc,
         }
         break;
       }
-      case kOptionLogFile: {
+      case kOptionLogFile:
+      case kOptionLogLevel: {
         // Handled by the pre-scan in HandlerMain before InitCrashpadLogging.
         break;
       }

--- a/handler/handler_main.cc
+++ b/handler/handler_main.cc
@@ -606,19 +606,24 @@ int HandlerMain(int argc,
   base::FilePath log_file_path;
   int min_log_level = logging::LOG_INFO;
   for (int i = 1; i < argc; ++i) {
-    if (!argv[i]) {
-      continue;
-    }
-    static constexpr char kLogFilePrefix[] = "--log-file=";
-    static constexpr char kLogLevelPrefix[] = "--log-level=";
-    if (strncmp(argv[i], kLogFilePrefix, sizeof(kLogFilePrefix) - 1) == 0) {
+    auto get_value = [&](const char* flag) -> const char* {
+      const size_t len = strlen(flag);
+      if (strncmp(argv[i], flag, len) == 0) {
+        if (argv[i][len] == '=') {
+          return argv[i] + len + 1;
+        }
+        if (argv[i][len] == '\0' && i + 1 < argc) {
+          return argv[++i];
+        }
+      }
+      return nullptr;
+    };
+    if (const char* file = get_value("--log-file")) {
       log_file_path = base::FilePath(
-          ToolSupport::CommandLineArgumentToFilePathStringType(
-              argv[i] + sizeof(kLogFilePrefix) - 1));
-    } else if (strncmp(argv[i], kLogLevelPrefix,
-                       sizeof(kLogLevelPrefix) - 1) == 0) {
-      int parsed;
-      if (StringToNumber(argv[i] + sizeof(kLogLevelPrefix) - 1, &parsed)) {
+          ToolSupport::CommandLineArgumentToFilePathStringType(file));
+    } else if (const char* level = get_value("--log-level")) {
+      int parsed = 0;
+      if (StringToNumber(level, &parsed)) {
         min_log_level = parsed;
       }
     }

--- a/handler/handler_main.cc
+++ b/handler/handler_main.cc
@@ -223,6 +223,7 @@ void Usage(const base::FilePath& me) {
   // clang-format on
 #endif  // BUILDFLAG(IS_ANDROID)
       // clang-format off
+"      --log-file=FILE         write handler log output to FILE\n"
 "      --help                  display this help and exit\n"
 "      --version               output version information and exit\n",
           me.value().c_str());
@@ -571,17 +572,22 @@ class ScopedStoppable {
   std::unique_ptr<Stoppable> stoppable_;
 };
 
-void InitCrashpadLogging() {
+void InitCrashpadLogging(const base::FilePath& log_file_path) {
   logging::LoggingSettings settings;
 #if BUILDFLAG(IS_CHROMEOS)
   settings.logging_dest = logging::LOG_TO_FILE;
-  settings.log_file_path = "/var/log/chrome/chrome";
+  settings.log_file_path =
+      base::FilePath(FILE_PATH_LITERAL("/var/log/chrome/chrome"));
 #elif BUILDFLAG(IS_WIN)
   settings.logging_dest = logging::LOG_TO_SYSTEM_DEBUG_LOG;
 #else
   settings.logging_dest =
       logging::LOG_TO_SYSTEM_DEBUG_LOG | logging::LOG_TO_STDERR;
 #endif
+  if (!log_file_path.empty()) {
+    settings.logging_dest |= logging::LOG_TO_FILE;
+    settings.log_file_path = log_file_path;
+  }
   logging::InitLogging(settings);
 }
 
@@ -590,7 +596,21 @@ void InitCrashpadLogging() {
 int HandlerMain(int argc,
                 char* argv[],
                 const UserStreamDataSources* user_stream_sources) {
-  InitCrashpadLogging();
+  // Pre-scan argv for --log-file= so that log output from HandlerMain
+  // (including option-parsing errors) is captured to the file.
+  base::FilePath log_file_path;
+  for (int i = 1; i < argc; ++i) {
+    static constexpr char kLogFilePrefix[] = "--log-file=";
+    if (argv[i] &&
+        strncmp(argv[i], kLogFilePrefix, sizeof(kLogFilePrefix) - 1) == 0) {
+      log_file_path = base::FilePath(
+          ToolSupport::CommandLineArgumentToFilePathStringType(
+              argv[i] + sizeof(kLogFilePrefix) - 1));
+      break;
+    }
+  }
+
+  InitCrashpadLogging(log_file_path);
 
   InstallCrashHandler();
   CallMetricsRecordNormalExit metrics_record_normal_exit;
@@ -661,6 +681,7 @@ int HandlerMain(int argc,
     kOptionCrashReporter,
     kOptionCrashEnvelope,
     kOptionReportID,
+    kOptionLogFile,
 
     // Standard options.
     kOptionHelp = -2,
@@ -761,6 +782,7 @@ int HandlerMain(int argc,
     {"crash-reporter", required_argument, nullptr, kOptionCrashReporter},
     {"crash-envelope", required_argument, nullptr, kOptionCrashEnvelope},
     {"report-id", required_argument, nullptr, kOptionReportID},
+    {"log-file", required_argument, nullptr, kOptionLogFile},
     {"help", no_argument, nullptr, kOptionHelp},
     {"version", no_argument, nullptr, kOptionVersion},
     {nullptr, 0, nullptr, 0},
@@ -973,6 +995,10 @@ int HandlerMain(int argc,
           ToolSupport::UsageHint(me, "failed to parse --report-id");
           return ExitFailure();
         }
+        break;
+      }
+      case kOptionLogFile: {
+        // Handled by the pre-scan in HandlerMain before InitCrashpadLogging.
         break;
       }
       case kOptionHelp: {

--- a/third_party/mini_chromium/CMakeLists.txt
+++ b/third_party/mini_chromium/CMakeLists.txt
@@ -23,6 +23,7 @@ mc_append_sources(
     debug/alias.h
     files/file_path.cc
     files/file_path.h
+    files/file_util.cc
     files/file_util.h
     files/scoped_file.cc
     files/scoped_file.h


### PR DESCRIPTION
Adds `--log-file` and `--log-level` options for the crashpad backend in sentry-native:
- https://github.com/getsentry/sentry-native/pull/1658

Forward log-file path and minimum severity to `mini_chromium` (https://github.com/getsentry/mini_chromium/pull/6), so handler log output can be redirected to a file and filtered to the requested severity.

- `--log-file=FILE` writes handler log output to `FILE` using the `LOG_TO_FILE` destination.
- `--log-level=N` sets the minimum `LogSeverity` that is emitted (-1=verbose, 0=info, 1=warning, 2=error, 4=fatal). Default remains `LOG_INFO`.

Both options are pre-scanned from `argv` before `InitCrashpadLogging` so they take effect early enough to cover option-parse diagnostics.

See also:
- https://github.com/getsentry/sentry-native/issues/1468