### PR TITLE
fix(arm32): use %progbits in .note.GNU-stack section directive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,12 @@ jobs:
             platform: ubuntu-22.04
             CC: clang
             CXX: clang++
+          - name: Linux Arm32 (gcc-arm-linux-gnueabihf)
+            platform: ubuntu-24.04-arm
+            CC: arm-linux-gnueabihf-gcc
+            CXX: arm-linux-gnueabihf-g++
+            LINUX_ARM32: 1
+            CMAKE_DEFINES: -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=arm -DCMAKE_ASM_COMPILER=arm-linux-gnueabihf-gcc
           - name: Alpine Linux (GCC + musl)
             platform: ubuntu-latest
             container: alpine:3.21
@@ -84,10 +90,21 @@ jobs:
           submodules: "recursive"
 
       - name: Installing Ubuntu Dependencies
-        if: ${{ runner.os == 'Linux' && !matrix.container }}
+        if: ${{ runner.os == 'Linux' && !matrix.container && !matrix.LINUX_ARM32 }}
         run: |
           sudo apt update
           sudo apt install clang zlib1g-dev libcurl4-openssl-dev libssl-dev libunwind-dev pkg-config
+
+      - name: Installing Linux arm32 Dependencies
+        if: ${{ runner.os == 'Linux' && matrix.LINUX_ARM32 && !matrix.container }}
+        run: |
+          sudo dpkg --add-architecture armhf
+          sudo apt update
+          sudo apt install -y \
+            cmake \
+            gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
+            zlib1g-dev:armhf libssl-dev:armhf libcurl4-openssl-dev:armhf \
+            libunwind-dev:armhf pkg-config
 
       - name: Installing LLVM-MINGW Dependencies
         if: ${{ runner.os == 'Windows' && matrix.MINGW == '1' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,7 @@ jobs:
             gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
             zlib1g-dev:armhf libssl-dev:armhf libcurl4-openssl-dev:armhf \
             libunwind-dev:armhf pkg-config
+          echo "PKG_CONFIG_LIBDIR=/usr/lib/arm-linux-gnueabihf/pkgconfig" >> "$GITHUB_ENV"
 
       - name: Installing LLVM-MINGW Dependencies
         if: ${{ runner.os == 'Windows' && matrix.MINGW == '1' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,14 @@ jobs:
             platform: ubuntu-22.04
             CC: clang
             CXX: clang++
+          - name: Linux Arm64 (GCC 13.3.0)
+            platform: ubuntu-24.04-arm
+            CC: gcc
+            CXX: g++
+          - name: Linux Arm64 (clang 18.1.3)
+            platform: ubuntu-24.04-arm
+            CC: clang
+            CXX: clang++
           - name: Linux Arm32 (gcc-arm-linux-gnueabihf)
             platform: ubuntu-24.04-arm
             CC: arm-linux-gnueabihf-gcc

--- a/client/crashpad_info_note.S
+++ b/client/crashpad_info_note.S
@@ -66,4 +66,4 @@ CRASHPAD_NOTE_REFERENCE:
   // linking Crashpad. The subtraction from |name| is a convenience to allow the
   // value to be computed statically.
   .quad name - CRASHPAD_NOTE
-  .section .note.GNU-stack,"",@progbits
+  .section .note.GNU-stack,"",%progbits


### PR DESCRIPTION
`@progbits` is silently dropped on ARM because `@` is the line-comment character in ARM assembler syntax, leaving `.section .note.GNU-stack,""` followed by an unrecognized comma — the assembler errors out with "junk at end of line, first unrecognized character is `,`".

Switch to `%progbits`, which works on every supported architecture and matches what the same file already does on the other two `.section` directives above:

https://github.com/getsentry/crashpad/blob/cd92de7e9e34af57c83e6bbc9a7fb598b47a6ed3/client/crashpad_info_note.S#L34

https://github.com/getsentry/crashpad/blob/cd92de7e9e34af57c83e6bbc9a7fb598b47a6ed3/client/crashpad_info_note.S#L56