### PR TITLE
fix(arm32): widen MinidumpContextARM::fpscr to uint64_t

### DIFF
--- a/minidump/minidump_context.h
+++ b/minidump/minidump_context.h
@@ -355,6 +355,7 @@ enum MinidumpContextARMFlags : uint32_t {
 };
 
 //! \brief A 32-bit ARM CPU context (register state) carried in a minidump file.
+//! \see https://github.com/rust-minidump/rust-minidump/blob/d4fefc765aad35b3bef569d53c1680eadab5a268/minidump-common/src/format.rs#L1034-L1055
 struct MinidumpContextARM {
   //! \brief A bitfield composed of values of #MinidumpContextFlags and
   //!     #MinidumpContextARMFlags.
@@ -375,7 +376,7 @@ struct MinidumpContextARM {
   uint32_t cpsr;
 
   //! \brief Floating-point status and control register.
-  uint32_t fpscr;
+  uint64_t fpscr;
 
   //! \brief VFP registers `d0`-`d31`.
   uint64_t vfp[32];

--- a/snapshot/minidump/minidump_context_converter.cc
+++ b/snapshot/minidump/minidump_context_converter.cc
@@ -158,7 +158,7 @@ bool MinidumpContextConverter::Initialize(
     context_.arm->lr = src->lr;
     context_.arm->pc = src->pc;
     context_.arm->cpsr = src->cpsr;
-    context_.arm->vfp_regs.fpscr = src->fpscr;
+    context_.arm->vfp_regs.fpscr = static_cast<uint32_t>(src->fpscr);
 
     for (size_t i = 0; i < std::size(src->vfp); i++) {
       context_.arm->vfp_regs.vfp[i] = src->vfp[i];


### PR DESCRIPTION
`MinidumpContextARM::fpscr` was declared as `uint32_t`, making the struct 364 bytes on disk. Other downstream readers of the ARM32 minidump context stream — breakpad's `MDRawContextARM`, rust-minidump's `CONTEXT_ARM`, the Sentry ingest path that uses rust-minidump — treat `fpscr` as `uint64_t` and expect a 368-byte struct, so crashpad's output was 4 bytes short and couldn't be fully deserialized.

The comment above the struct already noted that extra[8] is "included for compatibility with breakpad"; fpscr's width was the remaining divergence. Switch it to `uint64_t` so `sizeof(MinidumpContextARM) == 368`, matching breakpad / rust-minidump.

See also:
- https://github.com/getsentry/sentry-native/pull/1659#discussion_r3116758527
- https://github.com/rust-minidump/rust-minidump/blob/d4fefc765aad35b3bef569d53c1680eadab5a268/minidump-common/src/format.rs#L1034-L1055