### PR TITLE
feat: TUS upload for large attachments

### DIFF
--- a/client/crash_report_database.cc
+++ b/client/crash_report_database.cc
@@ -16,6 +16,8 @@
 
 #include <sys/stat.h>
 
+#include <utility>
+
 #include "base/logging.h"
 #include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
@@ -173,6 +175,26 @@ std::string MpackToJsonString(mpack_node_t node) {
   }
 }
 
+bool ReadReaderToString(FileReaderInterface* reader, std::string* data) {
+  if (!reader || !data) {
+    return false;
+  }
+
+  FileOffset current = reader->SeekGet();
+  if (current < 0 || !reader->SeekSet(0)) {
+    return false;
+  }
+
+  data->clear();
+  char buffer[4096];
+  FileOperationResult bytes_read;
+  while ((bytes_read = reader->Read(buffer, sizeof(buffer))) > 0) {
+    data->append(buffer, static_cast<size_t>(bytes_read));
+  }
+
+  return reader->SeekSet(current) && bytes_read == 0;
+}
+
 }  // namespace
 
 CrashReportDatabase::Report::Report()
@@ -310,16 +332,30 @@ bool CrashReportDatabase::Envelope::Initialize(const base::FilePath& path) {
   if (path.empty()) {
     return false;
   }
-  writer_ = std::make_unique<FileWriter>();
-  if (!writer_->Open(
+  file_writer_ = std::make_unique<FileWriter>();
+  if (!file_writer_->Open(
           path, FileWriteMode::kReuseOrCreate, FilePermissions::kOwnerOnly)) {
     return false;
   }
+  writer_ = file_writer_.get();
   writer_->Seek(0, SEEK_END);
   return true;
 }
 
-CrashReportDatabase::Envelope::Envelope(const UUID& uuid) : uuid_(uuid) {}
+bool CrashReportDatabase::Envelope::Initialize(FileWriterInterface* writer) {
+  if (!writer) {
+    return false;
+  }
+
+  file_writer_.reset();
+  writer_ = writer;
+  std::string header =
+      base::StringPrintf("{\"event_id\":\"%s\"}", uuid_.ToString().c_str());
+  return writer_->Write(header.data(), header.size());
+}
+
+CrashReportDatabase::Envelope::Envelope(const UUID& uuid)
+    : uuid_(uuid), writer_(nullptr) {}
 
 void CrashReportDatabase::Envelope::AddAttachments(
     const std::vector<base::FilePath>& attachments) {
@@ -348,8 +384,44 @@ void CrashReportDatabase::Envelope::AddAttachments(
   }
 }
 
+void CrashReportDatabase::Envelope::AddAttachments(
+    const std::map<std::string, FileReader*>& attachments) {
+  FileReader* event = nullptr;
+  std::vector<FileReader*> breadcrumbs;
+  std::vector<std::pair<std::string, FileReader*>> others;
+
+  for (const auto& attachment : attachments) {
+    if (attachment.first == "__sentry-event") {
+      event = attachment.second;
+    } else if (attachment.first.rfind("__sentry-breadcrumb", 0) == 0) {
+      breadcrumbs.push_back(attachment.second);
+    } else {
+      others.push_back(attachment);
+    }
+  }
+
+  std::string event_data;
+  if (ReadReaderToString(event, &event_data)) {
+    std::vector<std::string> breadcrumb_datas;
+    for (FileReader* breadcrumb : breadcrumbs) {
+      std::string breadcrumb_data;
+      if (ReadReaderToString(breadcrumb, &breadcrumb_data)) {
+        breadcrumb_datas.push_back(std::move(breadcrumb_data));
+      }
+    }
+    AddEvent(event_data, breadcrumb_datas);
+  }
+
+  for (const auto& attachment : others) {
+    AddAttachment(attachment.first, attachment.second);
+  }
+}
+
 void CrashReportDatabase::Envelope::AddMinidump(FileReaderInterface* reader) {
   FileOffset size = reader->Seek(0, SEEK_END);
+  if (size < 0) {
+    return;
+  }
   std::string header = base::StringPrintf(
       "{\"type\":\"attachment\","
       "\"length\":%zu,"
@@ -361,7 +433,26 @@ void CrashReportDatabase::Envelope::AddMinidump(FileReaderInterface* reader) {
   writer_->Write(header.data(), header.size());
   writer_->Write("\n", 1);
   reader->Seek(0, SEEK_SET);
-  CopyFileContent(reader, writer_.get());
+  CopyFileContent(reader, writer_);
+}
+
+void CrashReportDatabase::Envelope::AddMinidumpRef(
+    const std::string& filename,
+    const std::string& location,
+    uint64_t size) {
+  AddAttachmentRef(
+      filename, location, "application/octet-stream", "event.minidump", size);
+}
+
+void CrashReportDatabase::Envelope::AddAttachmentRef(
+    const std::string& filename,
+    const std::string& location,
+    uint64_t size) {
+  AddAttachmentRef(filename,
+                   location,
+                   "application/octet-stream",
+                   "event.attachment",
+                   size);
 }
 
 void CrashReportDatabase::Envelope::AddEvent(
@@ -372,23 +463,32 @@ void CrashReportDatabase::Envelope::AddEvent(
     return;
   }
 
+  std::vector<std::string> breadcrumb_datas;
+  for (const auto& breadcrumb : breadcrumbs) {
+    std::string breadcrumb_data;
+    if (LoggingReadEntireFile(breadcrumb, &breadcrumb_data)) {
+      breadcrumb_datas.push_back(std::move(breadcrumb_data));
+    }
+  }
+
+  AddEvent(event_data, breadcrumb_datas);
+}
+
+void CrashReportDatabase::Envelope::AddEvent(
+    const std::string& event_data,
+    const std::vector<std::string>& breadcrumb_datas) {
   mpack_tree_t event_obj;
   mpack_tree_init_data(&event_obj, event_data.data(), event_data.size());
   mpack_tree_parse(&event_obj);
   std::string event_json = MpackToJsonString(mpack_tree_root(&event_obj));
   mpack_tree_destroy(&event_obj);
 
-  // read all breadcrumb files
+  // read all breadcrumbs
   size_t max_breadcrumbs = 0;
   std::vector<std::unique_ptr<mpack_tree_t, mpack_error_t (*)(mpack_tree_t*)>>
       all_breadcrumbs;
-  std::vector<std::string> breadcrumb_datas(breadcrumbs.size());
-  for (size_t i = 0; i < breadcrumbs.size(); ++i) {
-    auto& breadcrumb_data = breadcrumb_datas[i];
-    if (!LoggingReadEntireFile(breadcrumbs[i], &breadcrumb_data)) {
-      continue;
-    }
-
+  for (size_t i = 0; i < breadcrumb_datas.size(); ++i) {
+    const auto& breadcrumb_data = breadcrumb_datas[i];
     size_t count = 0;
     size_t offset = 0;
     while (offset < breadcrumb_data.size()) {
@@ -444,7 +544,6 @@ void CrashReportDatabase::Envelope::AddEvent(
   writer_->Write(header.data(), header.size());
   writer_->Write("\n", 1);
   writer_->Write(payload.data(), payload.size());
-  writer_->Write("\n", 1);
 }
 
 void CrashReportDatabase::Envelope::AddAttachment(
@@ -471,11 +570,61 @@ void CrashReportDatabase::Envelope::AddAttachment(
   writer_->Write(header.data(), header.size());
   writer_->Write("\n", 1);
   writer_->Write(payload.data(), payload.size());
+}
+
+void CrashReportDatabase::Envelope::AddAttachment(
+    const std::string& filename,
+    FileReaderInterface* reader) {
+  FileOffset size = reader->Seek(0, SEEK_END);
+  if (size < 0) {
+    return;
+  }
+
+  std::string header = base::StringPrintf(
+      "{\"type\":\"attachment\","
+      "\"length\":%zu,"
+      "\"attachment_type\":\"event.attachment\","
+      "\"filename\":\"%s\"}",
+      static_cast<size_t>(size),
+      EscapeJsonString(filename).c_str());
   writer_->Write("\n", 1);
+  writer_->Write(header.data(), header.size());
+  writer_->Write("\n", 1);
+  reader->Seek(0, SEEK_SET);
+  CopyFileContent(reader, writer_);
+}
+
+void CrashReportDatabase::Envelope::AddAttachmentRef(
+    const std::string& filename,
+    const std::string& location,
+    const std::string& content_type,
+    const std::string& attachment_type,
+    uint64_t size) {
+  std::string payload = base::StringPrintf(
+      "{\"location\":\"%s\",\"content_type\":\"%s\"}",
+      EscapeJsonString(location).c_str(),
+      EscapeJsonString(content_type).c_str());
+  std::string header = base::StringPrintf(
+      "{\"type\":\"attachment\","
+      "\"length\":%zu,"
+      "\"content_type\":\"application/vnd.sentry.attachment-ref+json\","
+      "\"attachment_length\":%llu,"
+      "\"attachment_type\":\"%s\","
+      "\"filename\":\"%s\"}",
+      payload.size(),
+      static_cast<unsigned long long>(size),
+      EscapeJsonString(attachment_type).c_str(),
+      EscapeJsonString(filename).c_str());
+  writer_->Write("\n", 1);
+  writer_->Write(header.data(), header.size());
+  writer_->Write("\n", 1);
+  writer_->Write(payload.data(), payload.size());
 }
 
 void CrashReportDatabase::Envelope::Finish() {
-  writer_->Close();
+  if (file_writer_) {
+    file_writer_->Close();
+  }
 }
 
 CrashReportDatabase::OperationStatus CrashReportDatabase::RecordUploadComplete(

--- a/client/crash_report_database.cc
+++ b/client/crash_report_database.cc
@@ -195,6 +195,14 @@ bool ReadReaderToString(FileReaderInterface* reader, std::string* data) {
   return reader->SeekSet(current) && bytes_read == 0;
 }
 
+std::string AttachmentNameForPath(const base::FilePath& attachment) {
+#if BUILDFLAG(IS_WIN)
+  return base::WideToUTF8(attachment.BaseName().value());
+#else
+  return attachment.BaseName().value();
+#endif
+}
+
 }  // namespace
 
 CrashReportDatabase::Report::Report()
@@ -328,7 +336,6 @@ bool CrashReportDatabase::UploadReport::Initialize(const base::FilePath& path,
 }
 
 bool CrashReportDatabase::Envelope::Initialize(const base::FilePath& path) {
-  path_ = path;
   if (path.empty()) {
     return false;
   }
@@ -359,51 +366,61 @@ CrashReportDatabase::Envelope::Envelope(const UUID& uuid)
 
 void CrashReportDatabase::Envelope::AddAttachments(
     const std::vector<base::FilePath>& attachments) {
-  base::FilePath event;
-  std::vector<base::FilePath> breadcrumbs;
-  std::vector<base::FilePath> others;
+  std::vector<std::unique_ptr<FileReader>> readers;
+  std::vector<Attachment> named_attachments;
+  readers.reserve(attachments.size());
+  named_attachments.reserve(attachments.size());
 
   for (const auto& attachment : attachments) {
-#if BUILDFLAG(IS_WIN)
-    std::string basename = base::WideToUTF8(attachment.BaseName().value());
-#else
-    std::string basename = attachment.BaseName().value();
-#endif
-    if (basename == "__sentry-event") {
-      event = attachment;
-    } else if (basename.rfind("__sentry-breadcrumb", 0) == 0) {
-      breadcrumbs.push_back(attachment);
-    } else {
-      others.push_back(attachment);
+    auto reader = std::make_unique<FileReader>();
+    if (!reader->Open(attachment)) {
+      continue;
     }
+
+    named_attachments.push_back({AttachmentNameForPath(attachment),
+                                 reader.get()});
+    readers.push_back(std::move(reader));
   }
 
-  AddEvent(event, breadcrumbs);
-  for (const auto& attachment : others) {
-    AddAttachment(attachment);
-  }
+  AddAttachments(named_attachments);
 }
 
 void CrashReportDatabase::Envelope::AddAttachments(
     const std::map<std::string, FileReader*>& attachments) {
-  FileReader* event = nullptr;
-  std::vector<FileReader*> breadcrumbs;
-  std::vector<std::pair<std::string, FileReader*>> others;
+  std::vector<Attachment> named_attachments;
+  named_attachments.reserve(attachments.size());
 
   for (const auto& attachment : attachments) {
-    if (attachment.first == "__sentry-event") {
-      event = attachment.second;
-    } else if (attachment.first.rfind("__sentry-breadcrumb", 0) == 0) {
-      breadcrumbs.push_back(attachment.second);
+    named_attachments.push_back({attachment.first, attachment.second});
+  }
+
+  AddAttachments(named_attachments);
+}
+
+void CrashReportDatabase::Envelope::AddAttachments(
+    const std::vector<Attachment>& attachments) {
+  FileReaderInterface* event = nullptr;
+  std::vector<FileReaderInterface*> breadcrumbs;
+  std::vector<const Attachment*> others;
+
+  for (const auto& attachment : attachments) {
+    if (!attachment.reader) {
+      continue;
+    }
+
+    if (attachment.name == "__sentry-event") {
+      event = attachment.reader;
+    } else if (attachment.name.rfind("__sentry-breadcrumb", 0) == 0) {
+      breadcrumbs.push_back(attachment.reader);
     } else {
-      others.push_back(attachment);
+      others.push_back(&attachment);
     }
   }
 
   std::string event_data;
   if (ReadReaderToString(event, &event_data)) {
     std::vector<std::string> breadcrumb_datas;
-    for (FileReader* breadcrumb : breadcrumbs) {
+    for (FileReaderInterface* breadcrumb : breadcrumbs) {
       std::string breadcrumb_data;
       if (ReadReaderToString(breadcrumb, &breadcrumb_data)) {
         breadcrumb_datas.push_back(std::move(breadcrumb_data));
@@ -412,8 +429,8 @@ void CrashReportDatabase::Envelope::AddAttachments(
     AddEvent(event_data, breadcrumb_datas);
   }
 
-  for (const auto& attachment : others) {
-    AddAttachment(attachment.first, attachment.second);
+  for (const Attachment* attachment : others) {
+    AddAttachment(attachment->name, attachment->reader);
   }
 }
 
@@ -456,27 +473,8 @@ void CrashReportDatabase::Envelope::AddAttachmentRef(
 }
 
 void CrashReportDatabase::Envelope::AddEvent(
-    const base::FilePath& event,
-    const std::vector<base::FilePath>& breadcrumbs) {
-  std::string event_data;
-  if (!LoggingReadEntireFile(event, &event_data)) {
-    return;
-  }
-
-  std::vector<std::string> breadcrumb_datas;
-  for (const auto& breadcrumb : breadcrumbs) {
-    std::string breadcrumb_data;
-    if (LoggingReadEntireFile(breadcrumb, &breadcrumb_data)) {
-      breadcrumb_datas.push_back(std::move(breadcrumb_data));
-    }
-  }
-
-  AddEvent(event_data, breadcrumb_datas);
-}
-
-void CrashReportDatabase::Envelope::AddEvent(
     const std::string& event_data,
-    const std::vector<std::string>& breadcrumb_datas) {
+    const std::vector<std::string>& breadcrumbs_datas) {
   mpack_tree_t event_obj;
   mpack_tree_init_data(&event_obj, event_data.data(), event_data.size());
   mpack_tree_parse(&event_obj);
@@ -487,8 +485,8 @@ void CrashReportDatabase::Envelope::AddEvent(
   size_t max_breadcrumbs = 0;
   std::vector<std::unique_ptr<mpack_tree_t, mpack_error_t (*)(mpack_tree_t*)>>
       all_breadcrumbs;
-  for (size_t i = 0; i < breadcrumb_datas.size(); ++i) {
-    const auto& breadcrumb_data = breadcrumb_datas[i];
+  for (size_t i = 0; i < breadcrumbs_datas.size(); ++i) {
+    const auto& breadcrumb_data = breadcrumbs_datas[i];
     size_t count = 0;
     size_t offset = 0;
     while (offset < breadcrumb_data.size()) {
@@ -540,32 +538,6 @@ void CrashReportDatabase::Envelope::AddEvent(
       "{\"type\":\"event\","
       "\"length\":%zu}",
       payload.size());
-  writer_->Write("\n", 1);
-  writer_->Write(header.data(), header.size());
-  writer_->Write("\n", 1);
-  writer_->Write(payload.data(), payload.size());
-}
-
-void CrashReportDatabase::Envelope::AddAttachment(
-    const base::FilePath& attachment) {
-  std::string payload;
-  if (!LoggingReadEntireFile(attachment, &payload)) {
-    return;
-  }
-
-#if BUILDFLAG(IS_WIN)
-  std::string basename = base::WideToUTF8(attachment.BaseName().value());
-#else
-  std::string basename = attachment.BaseName().value();
-#endif
-
-  std::string header = base::StringPrintf(
-      "{\"type\":\"attachment\","
-      "\"length\":%zu,"
-      "\"attachment_type\":\"event.attachment\","
-      "\"filename\": \"%s\"}",
-      payload.size(),
-      EscapeJsonString(basename).c_str());
   writer_->Write("\n", 1);
   writer_->Write(header.data(), header.size());
   writer_->Write("\n", 1);

--- a/client/crash_report_database.h
+++ b/client/crash_report_database.h
@@ -210,13 +210,38 @@ class CrashReportDatabase {
     //! \return true on success, false on failure.
     bool Initialize(const base::FilePath& path);
 
+    //! \brief Initializes the report with a writer and writes envelope headers.
+    //! \param[in] writer The writer where the report will be written.
+    //! \return true on success, false on failure.
+    bool Initialize(FileWriterInterface* writer);
+
     //! \brief Adds attachments to the feedback report.
     //! \param[in] attachments Vector of file paths to attach.
     void AddAttachments(const std::vector<base::FilePath>& attachments);
 
+    //! \brief Adds attachments to the feedback report.
+    //! \param[in] attachments Map of file names to file readers.
+    void AddAttachments(const std::map<std::string, FileReader*>& attachments);
+
     //! \brief Adds minidump data to the feedback report.
     //! \param[in] reader File reader for the minidump data.
     void AddMinidump(FileReaderInterface* reader);
+
+    //! \brief Adds a minidump reference to the feedback report.
+    //! \param[in] filename The file name to use in the envelope item.
+    //! \param[in] location The upload location for the minidump.
+    //! \param[in] size The size of the minidump in bytes.
+    void AddMinidumpRef(const std::string& filename,
+                        const std::string& location,
+                        uint64_t size);
+
+    //! \brief Adds an attachment reference to the feedback report.
+    //! \param[in] filename The file name to use in the envelope item.
+    //! \param[in] location The upload location for the attachment.
+    //! \param[in] size The size of the attachment in bytes.
+    void AddAttachmentRef(const std::string& filename,
+                          const std::string& location,
+                          uint64_t size);
 
     //! \brief Finalizes the feedback report and closes file handles.
     void Finish();
@@ -224,11 +249,21 @@ class CrashReportDatabase {
    private:
     void AddEvent(const base::FilePath& event,
                   const std::vector<base::FilePath>& breadcrumbs);
+    void AddEvent(const std::string& event_data,
+                  const std::vector<std::string>& breadcrumb_datas);
     void AddAttachment(const base::FilePath& attachment);
+    void AddAttachment(const std::string& filename,
+                       FileReaderInterface* reader);
+    void AddAttachmentRef(const std::string& filename,
+                          const std::string& location,
+                          const std::string& content_type,
+                          const std::string& attachment_type,
+                          uint64_t size);
 
     UUID uuid_;
     base::FilePath path_;
-    std::unique_ptr<FileWriter> writer_;
+    std::unique_ptr<FileWriter> file_writer_;
+    FileWriterInterface* writer_;
   };
 
   //! \brief The result code for operations performed on a database.

--- a/client/crash_report_database.h
+++ b/client/crash_report_database.h
@@ -247,11 +247,14 @@ class CrashReportDatabase {
     void Finish();
 
    private:
-    void AddEvent(const base::FilePath& event,
-                  const std::vector<base::FilePath>& breadcrumbs);
+    struct Attachment {
+      std::string name;
+      FileReaderInterface* reader;
+    };
+
+    void AddAttachments(const std::vector<Attachment>& attachments);
     void AddEvent(const std::string& event_data,
-                  const std::vector<std::string>& breadcrumb_datas);
-    void AddAttachment(const base::FilePath& attachment);
+                  const std::vector<std::string>& breadcrumbs_datas);
     void AddAttachment(const std::string& filename,
                        FileReaderInterface* reader);
     void AddAttachmentRef(const std::string& filename,
@@ -261,7 +264,6 @@ class CrashReportDatabase {
                           uint64_t size);
 
     UUID uuid_;
-    base::FilePath path_;
     std::unique_ptr<FileWriter> file_writer_;
     FileWriterInterface* writer_;
   };

--- a/client/ios_handler/in_process_handler.cc
+++ b/client/ios_handler/in_process_handler.cc
@@ -88,6 +88,7 @@ bool InProcessHandler::Initialize(
     CrashReportUploadThread::Options upload_thread_options;
     upload_thread_options.rate_limit = false;
     upload_thread_options.upload_gzip = true;
+    upload_thread_options.enable_large_attachments = false;
     upload_thread_options.watch_pending_reports = true;
     upload_thread_options.identify_client_via_url = true;
 

--- a/handler/crash_report_upload_thread.cc
+++ b/handler/crash_report_upload_thread.cc
@@ -629,7 +629,6 @@ CrashReportUploadThread::UploadResult CrashReportUploadThread::UploadReport(
     if (large_attachment_upload_available &&
         minidump_size >= kSentryLargeAttachmentSize &&
         minidump_size <= kSentryMaxAttachmentSize) {
-      std::string location;
       if (UploadLargeAttachment(large_attachment_upload_context,
                                 http_proxy_,
                                 minidump_name,

--- a/handler/crash_report_upload_thread.cc
+++ b/handler/crash_report_upload_thread.cc
@@ -269,6 +269,7 @@ bool UploadLargeAttachmentBytes(const LargeAttachmentUploadContext& context,
       std::make_unique<FileReaderHTTPBodyStream>(reader));
   http_transport->SetExpectedResponseCode(204);
   http_transport->SetTimeout(internal::kUploadReportTimeoutSeconds);
+  http_transport->SetTransferTimeout(0);
 
   std::string response_body;
   const bool ok = http_transport->ExecuteSynchronously(&response_body);

--- a/handler/crash_report_upload_thread.cc
+++ b/handler/crash_report_upload_thread.cc
@@ -155,8 +155,7 @@ bool BuildLargeAttachmentUploadContext(const std::string& minidump_url,
     return false;
   }
 
-  context->origin = base::StringPrintf(
-      "%s://%s:%s", scheme.c_str(), host.c_str(), port.c_str());
+  context->origin = minidump_url.substr(0, minidump_url.size() - rest.size());
   context->upload_url =
       context->origin +
       path.substr(0, path.size() - strlen(kMinidumpPathSuffix)) + "/upload/";

--- a/handler/crash_report_upload_thread.cc
+++ b/handler/crash_report_upload_thread.cc
@@ -612,7 +612,9 @@ CrashReportUploadThread::UploadResult CrashReportUploadThread::UploadReport(
           continue;
         }
 
-        return UploadResult::kRetry;
+        if (large_attachment_upload_available) {
+          return UploadResult::kRetry;
+        }
       }
     }
 
@@ -639,7 +641,7 @@ CrashReportUploadThread::UploadResult CrashReportUploadThread::UploadReport(
                                 &large_attachment_upload_available,
                                 &minidump_location)) {
         minidump_uploaded_separately = true;
-      } else {
+      } else if (large_attachment_upload_available) {
         return UploadResult::kRetry;
       }
     }

--- a/handler/crash_report_upload_thread.cc
+++ b/handler/crash_report_upload_thread.cc
@@ -15,11 +15,15 @@
 #include "handler/crash_report_upload_thread.h"
 
 #include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
 #include <time.h>
 
 #include <algorithm>
 #include <map>
 #include <memory>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -34,12 +38,14 @@
 #include "snapshot/minidump/process_snapshot_minidump.h"
 #include "snapshot/module_snapshot.h"
 #include "util/file/file_reader.h"
+#include "util/file/string_file.h"
 #include "util/misc/metrics.h"
 #include "util/misc/uuid.h"
 #include "util/net/http_body.h"
 #include "util/net/http_multipart_builder.h"
 #include "util/net/http_transport.h"
 #include "util/net/url.h"
+#include "util/numeric/safe_assignment.h"
 #include "util/stdlib/map_insert.h"
 
 #if BUILDFLAG(IS_APPLE)
@@ -62,6 +68,276 @@ const int kRetryWorkIntervalSeconds = 15 * 60;
 // ReportPending(), and, if Options.watch_pending_reports is true, once every
 // kRetryWorkIntervalSeconds.
 const int kRetryAttempts = 5;
+
+constexpr uint64_t kSentryLargeAttachmentSize = 100ull * 1024 * 1024;  // 100 MiB
+constexpr uint64_t kSentryMaxAttachmentSize = 1024ull * 1024 * 1024;  // 1 GiB
+constexpr char kTusResumable[] = "1.0.0";
+constexpr char kTusMime[] = "application/offset+octet-stream";
+
+struct LargeAttachmentUploadContext {
+  std::string origin;
+  std::string upload_url;
+  std::string envelope_url;
+  std::string auth_header;
+};
+
+struct UploadedLargeAttachment {
+  std::string name;
+  std::string location;
+  uint64_t size;
+};
+
+bool StartsWith(const std::string& string, const char* prefix) {
+  return string.compare(0, strlen(prefix), prefix) == 0;
+}
+
+bool EndsWith(const std::string& string, const char* suffix) {
+  const size_t suffix_length = strlen(suffix);
+  return string.size() >= suffix_length &&
+         string.compare(string.size() - suffix_length, suffix_length, suffix) ==
+             0;
+}
+
+char LowerASCII(char c) {
+  return c >= 'A' && c <= 'Z' ? c + ('a' - 'A') : c;
+}
+
+bool EqualsCaseInsensitiveASCII(const std::string& lhs,
+                                const std::string& rhs) {
+  if (lhs.size() != rhs.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    if (LowerASCII(lhs[i]) != LowerASCII(rhs[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::string HeaderValue(const HTTPHeaders& headers, const char* name) {
+  for (const auto& header : headers) {
+    if (EqualsCaseInsensitiveASCII(header.first, name)) {
+      return header.second;
+    }
+  }
+  return std::string();
+}
+
+std::string QueryValue(const std::string& query, const char* name) {
+  size_t start = 0;
+  while (start <= query.size()) {
+    size_t end = query.find('&', start);
+    if (end == std::string::npos) {
+      end = query.size();
+    }
+
+    const std::string pair = query.substr(start, end - start);
+    const size_t equals = pair.find('=');
+    if (equals != std::string::npos && pair.compare(0, equals, name) == 0) {
+      return pair.substr(equals + 1);
+    }
+
+    if (end == query.size()) {
+      break;
+    }
+    start = end + 1;
+  }
+  return std::string();
+}
+
+bool BuildLargeAttachmentUploadContext(const std::string& minidump_url,
+                                       LargeAttachmentUploadContext* context) {
+  std::string scheme;
+  std::string host;
+  std::string port;
+  std::string rest;
+  if (!CrackURL(minidump_url, &scheme, &host, &port, &rest)) {
+    return false;
+  }
+
+  const size_t query_separator = rest.find('?');
+  const std::string path = rest.substr(0, query_separator);
+  const std::string query = query_separator == std::string::npos
+                                ? std::string()
+                                : rest.substr(query_separator + 1);
+  static constexpr char kMinidumpPathSuffix[] = "/minidump/";
+  if (!EndsWith(path, kMinidumpPathSuffix)) {
+    return false;
+  }
+
+  const std::string sentry_key = QueryValue(query, "sentry_key");
+  if (sentry_key.empty()) {
+    return false;
+  }
+
+  context->origin = base::StringPrintf(
+      "%s://%s:%s", scheme.c_str(), host.c_str(), port.c_str());
+  context->upload_url =
+      context->origin +
+      path.substr(0, path.size() - strlen(kMinidumpPathSuffix)) + "/upload/";
+  context->envelope_url =
+      context->origin +
+      path.substr(0, path.size() - strlen(kMinidumpPathSuffix)) + "/envelope/";
+
+  context->auth_header =
+      "Sentry sentry_key=" + sentry_key + ", sentry_version=7";
+  const std::string sentry_client = QueryValue(query, "sentry_client");
+  if (!sentry_client.empty()) {
+    context->auth_header += ", sentry_client=" + sentry_client;
+  }
+
+  return true;
+}
+
+std::string ResolveLargeAttachmentUploadLocation(
+    const LargeAttachmentUploadContext& context,
+    const std::string& location) {
+  if (StartsWith(location, "http://") || StartsWith(location, "https://")) {
+    return location;
+  }
+  if (!location.empty() && location[0] == '/') {
+    return context.origin + location;
+  }
+  return location;
+}
+
+bool GetReaderSize(FileReaderInterface* reader, uint64_t* size) {
+  const FileOffset current = reader->SeekGet();
+  if (current < 0) {
+    return false;
+  }
+
+  const FileOffset end = reader->Seek(0, SEEK_END);
+  if (end < 0) {
+    reader->SeekSet(current);
+    return false;
+  }
+
+  const bool assigned = AssignIfInRange(size, end);
+  if (!reader->SeekSet(current)) {
+    return false;
+  }
+  return assigned;
+}
+
+bool CreateLargeAttachmentUpload(const LargeAttachmentUploadContext& context,
+                                 const std::string& http_proxy,
+                                 uint64_t upload_size,
+                                 bool* upload_available,
+                                 std::string* location) {
+  std::unique_ptr<HTTPTransport> http_transport(HTTPTransport::Create());
+  if (!http_transport) {
+    return false;
+  }
+
+  http_transport->SetURL(context.upload_url);
+  http_transport->SetHTTPProxy(http_proxy);
+  http_transport->SetHeader("x-sentry-auth", context.auth_header);
+  http_transport->SetHeader("tus-resumable", kTusResumable);
+  http_transport->SetHeader("upload-length", std::to_string(upload_size));
+  http_transport->SetHeader(kContentLength, "0");
+  http_transport->SetBodyStream(std::make_unique<StringHTTPBodyStream>(""));
+  http_transport->SetExpectedResponseCode(201);
+  http_transport->SetTimeout(internal::kUploadReportTimeoutSeconds);
+
+  std::string response_body;
+  if (!http_transport->ExecuteSynchronously(&response_body)) {
+    if (http_transport->response_code() == 404) {
+      LOG(WARNING) << "large attachment upload endpoint returned 404, "
+                      "disabling separate upload";
+      *upload_available = false;
+    }
+    return false;
+  }
+
+  *location = HeaderValue(http_transport->response_headers(), "Location");
+  if (location->empty()) {
+    LOG(WARNING) << "large attachment upload response did not include Location";
+    return false;
+  }
+  return true;
+}
+
+bool UploadLargeAttachmentBytes(const LargeAttachmentUploadContext& context,
+                                const std::string& http_proxy,
+                                FileReaderInterface* reader,
+                                uint64_t upload_size,
+                                const std::string& location) {
+  if (!reader->SeekSet(0)) {
+    return false;
+  }
+
+  std::unique_ptr<HTTPTransport> http_transport(HTTPTransport::Create());
+  if (!http_transport) {
+    return false;
+  }
+
+  http_transport->SetURL(
+      ResolveLargeAttachmentUploadLocation(context, location));
+  http_transport->SetHTTPProxy(http_proxy);
+  http_transport->SetMethod("PATCH");
+  http_transport->SetHeader("x-sentry-auth", context.auth_header);
+  http_transport->SetHeader("tus-resumable", kTusResumable);
+  http_transport->SetHeader(kContentType, kTusMime);
+  http_transport->SetHeader("upload-offset", "0");
+  http_transport->SetHeader(kContentLength, std::to_string(upload_size));
+  http_transport->SetBodyStream(
+      std::make_unique<FileReaderHTTPBodyStream>(reader));
+  http_transport->SetExpectedResponseCode(204);
+  http_transport->SetTimeout(internal::kUploadReportTimeoutSeconds);
+
+  std::string response_body;
+  const bool ok = http_transport->ExecuteSynchronously(&response_body);
+  reader->SeekSet(0);
+  return ok;
+}
+
+bool UploadLargeAttachment(const LargeAttachmentUploadContext& context,
+                           const std::string& http_proxy,
+                           const std::string& attachment_name,
+                           FileReaderInterface* reader,
+                           uint64_t upload_size,
+                           bool* upload_available,
+                           std::string* location) {
+  if (!CreateLargeAttachmentUpload(
+          context, http_proxy, upload_size, upload_available, location)) {
+    return false;
+  }
+
+  if (!UploadLargeAttachmentBytes(
+          context, http_proxy, reader, upload_size, *location)) {
+    LOG(WARNING) << "large attachment upload failed for " << attachment_name;
+    location->clear();
+    reader->SeekSet(0);
+    return false;
+  }
+
+  return true;
+}
+
+bool UploadLargeAttachmentEnvelope(const LargeAttachmentUploadContext& context,
+                                   const std::string& http_proxy,
+                                   const StringFile& envelope,
+                                   std::string* response_body) {
+  std::unique_ptr<HTTPTransport> http_transport(HTTPTransport::Create());
+  if (!http_transport) {
+    return false;
+  }
+
+  http_transport->SetURL(context.envelope_url);
+  http_transport->SetHTTPProxy(http_proxy);
+  http_transport->SetHeader("x-sentry-auth", context.auth_header);
+  http_transport->SetHeader(kContentType, "application/x-sentry-envelope");
+  http_transport->SetHeader(kContentLength,
+                            std::to_string(envelope.string().size()));
+  http_transport->SetBodyStream(
+      std::make_unique<StringHTTPBodyStream>(envelope.string()));
+  http_transport->SetTimeout(internal::kUploadReportTimeoutSeconds);
+
+  return http_transport->ExecuteSynchronously(response_body);
+}
 
 // Wraps a reference to a no-args function (which can be empty). When this
 // object goes out of scope, invokes the function if it is non-empty.
@@ -310,10 +586,110 @@ CrashReportUploadThread::UploadResult CrashReportUploadThread::UploadReport(
     return UploadResult::kPermanentFailure;
   }
 
+  static constexpr char kMinidumpKey[] = "upload_file_minidump";
+
+  LargeAttachmentUploadContext large_attachment_upload_context;
+  bool large_attachment_upload_available =
+      options_.enable_large_attachments &&
+      BuildLargeAttachmentUploadContext(url_, &large_attachment_upload_context);
+  if (options_.enable_large_attachments && !large_attachment_upload_available) {
+    LOG(WARNING) << "large attachments enabled, but large attachment upload "
+                    "context could not be derived from the report URL";
+  }
+
+  std::map<std::string, FileReader*> attachments = report->GetAttachments();
+  std::vector<UploadedLargeAttachment> uploaded_attachments;
+  for (auto it = attachments.begin(); it != attachments.end();) {
+    if (options_.enable_large_attachments) {
+      uint64_t attachment_size = 0;
+      if (!GetReaderSize(it->second, &attachment_size)) {
+        return UploadResult::kPermanentFailure;
+      }
+
+      if (attachment_size > kSentryMaxAttachmentSize) {
+        LOG(WARNING) << "discarding attachment " << it->first
+                     << " because it exceeds the maximum attachment size";
+        it = attachments.erase(it);
+        continue;
+      }
+
+      if (large_attachment_upload_available &&
+          attachment_size >= kSentryLargeAttachmentSize) {
+        std::string location;
+        if (UploadLargeAttachment(large_attachment_upload_context,
+                                  http_proxy_,
+                                  it->first,
+                                  it->second,
+                                  attachment_size,
+                                  &large_attachment_upload_available,
+                                  &location)) {
+          uploaded_attachments.push_back(
+              {it->first, location, attachment_size});
+          it = attachments.erase(it);
+          continue;
+        }
+      }
+    }
+
+    ++it;
+  }
+
+  const std::string minidump_name = report->uuid.ToString() + ".dmp";
+  bool minidump_uploaded_separately = false;
+  uint64_t minidump_size = 0;
+  std::string minidump_location;
+  if (options_.enable_large_attachments) {
+    if (!GetReaderSize(reader, &minidump_size)) {
+      return UploadResult::kPermanentFailure;
+    }
+
+    if (large_attachment_upload_available &&
+        minidump_size >= kSentryLargeAttachmentSize &&
+        minidump_size <= kSentryMaxAttachmentSize) {
+      std::string location;
+      if (UploadLargeAttachment(large_attachment_upload_context,
+                                http_proxy_,
+                                minidump_name,
+                                reader,
+                                minidump_size,
+                                &large_attachment_upload_available,
+                                &minidump_location)) {
+        minidump_uploaded_separately = true;
+      }
+    }
+  }
+
+  if (minidump_uploaded_separately || !uploaded_attachments.empty()) {
+    StringFile envelope_file;
+    CrashReportDatabase::Envelope envelope(report->uuid);
+    if (!envelope.Initialize(&envelope_file)) {
+      return UploadResult::kPermanentFailure;
+    }
+
+    envelope.AddAttachments(attachments);
+    if (minidump_uploaded_separately) {
+      envelope.AddMinidumpRef(minidump_name, minidump_location, minidump_size);
+    } else {
+      envelope.AddMinidump(reader);
+    }
+    for (const auto& attachment : uploaded_attachments) {
+      envelope.AddAttachmentRef(
+          attachment.name, attachment.location, attachment.size);
+    }
+    envelope.Finish();
+
+    if (!UploadLargeAttachmentEnvelope(large_attachment_upload_context,
+                                       http_proxy_,
+                                       envelope_file,
+                                       response_body)) {
+      return UploadResult::kRetry;
+    }
+
+    return UploadResult::kSuccess;
+  }
+
   HTTPMultipartBuilder http_multipart_builder;
   http_multipart_builder.SetGzipEnabled(options_.upload_gzip);
-
-  static constexpr char kMinidumpKey[] = "upload_file_minidump";
 
   for (const auto& kv : parameters) {
     if (kv.first == kMinidumpKey) {
@@ -324,13 +700,13 @@ CrashReportUploadThread::UploadResult CrashReportUploadThread::UploadReport(
     }
   }
 
-  for (const auto& it : report->GetAttachments()) {
+  for (const auto& it : attachments) {
     http_multipart_builder.SetFileAttachment(
         it.first, it.first, it.second, "application/octet-stream");
   }
 
   http_multipart_builder.SetFileAttachment(kMinidumpKey,
-                                           report->uuid.ToString() + ".dmp",
+                                           minidump_name,
                                            reader,
                                            "application/octet-stream");
 

--- a/handler/crash_report_upload_thread.cc
+++ b/handler/crash_report_upload_thread.cc
@@ -611,6 +611,8 @@ CrashReportUploadThread::UploadResult CrashReportUploadThread::UploadReport(
           it = attachments.erase(it);
           continue;
         }
+
+        return UploadResult::kRetry;
       }
     }
 
@@ -637,6 +639,8 @@ CrashReportUploadThread::UploadResult CrashReportUploadThread::UploadReport(
                                 &large_attachment_upload_available,
                                 &minidump_location)) {
         minidump_uploaded_separately = true;
+      } else {
+        return UploadResult::kRetry;
       }
     }
   }

--- a/handler/crash_report_upload_thread.cc
+++ b/handler/crash_report_upload_thread.cc
@@ -42,6 +42,7 @@
 #include "util/misc/metrics.h"
 #include "util/misc/uuid.h"
 #include "util/net/http_body.h"
+#include "util/net/http_headers.h"
 #include "util/net/http_multipart_builder.h"
 #include "util/net/http_transport.h"
 #include "util/net/url.h"
@@ -98,27 +99,9 @@ bool EndsWith(const std::string& string, const char* suffix) {
              0;
 }
 
-char LowerASCII(char c) {
-  return c >= 'A' && c <= 'Z' ? c + ('a' - 'A') : c;
-}
-
-bool EqualsCaseInsensitiveASCII(const std::string& lhs,
-                                const std::string& rhs) {
-  if (lhs.size() != rhs.size()) {
-    return false;
-  }
-
-  for (size_t i = 0; i < lhs.size(); ++i) {
-    if (LowerASCII(lhs[i]) != LowerASCII(rhs[i])) {
-      return false;
-    }
-  }
-  return true;
-}
-
 std::string HeaderValue(const HTTPHeaders& headers, const char* name) {
   for (const auto& header : headers) {
-    if (EqualsCaseInsensitiveASCII(header.first, name)) {
+    if (HTTPHeaderNameEquals(header.first, name)) {
       return header.second;
     }
   }

--- a/handler/crash_report_upload_thread.h
+++ b/handler/crash_report_upload_thread.h
@@ -57,6 +57,9 @@ class CrashReportUploadThread : public WorkerThread::Delegate,
     //! Whether uploads should use `gzip` compression.
     bool upload_gzip;
 
+    //! Whether large attachments should be handled by the upload thread.
+    bool enable_large_attachments;
+
     //! Whether to periodically check for new pending reports not already known
     //! to exist. When `false`, only an initial upload attempt will be made for
     //! reports known to exist by having been added by the ReportPending()

--- a/handler/handler_main.cc
+++ b/handler/handler_main.cc
@@ -116,6 +116,10 @@ void Usage(const base::FilePath& me) {
 "                              at the time of the crash\n"
   // clang-format on
 #endif  // ATTACHMENTS_SUPPORTED
+      // clang-format off
+"      --enable-large-attachments\n"
+"                              enable separate upload for large attachments\n"
+  // clang-format on
 #if defined(SCREENSHOT_SUPPORTED)
       // clang-format off
 "      --screenshot=FILE_PATH  capture a screenshot to FILE_PATH\n"
@@ -260,6 +264,7 @@ struct Options {
   InitialClientData initial_client_data;
 #endif  // BUILDFLAG(IS_APPLE)
   bool identify_client_via_url;
+  bool enable_large_attachments;
   bool monitor_self;
   bool periodic_tasks;
   bool rate_limit;
@@ -514,6 +519,9 @@ void MonitorSelf(const Options& options) {
   if (!options.upload_gzip) {
     extra_arguments.push_back("--no-upload-gzip");
   }
+  if (options.enable_large_attachments) {
+    extra_arguments.push_back("--enable-large-attachments");
+  }
   for (const auto& iterator : options.monitor_self_annotations) {
     extra_arguments.push_back(
         base::StringPrintf("--monitor-self-annotation=%s=%s",
@@ -662,6 +670,7 @@ int HandlerMain(int argc,
 #if BUILDFLAG(IS_APPLE)
     kOptionMachService,
 #endif  // BUILDFLAG(IS_APPLE)
+    kOptionEnableLargeAttachments,
     kOptionMetrics,
     kOptionMonitorSelf,
     kOptionMonitorSelfAnnotation,
@@ -733,6 +742,10 @@ int HandlerMain(int argc,
 #if BUILDFLAG(IS_APPLE)
     {"mach-service", required_argument, nullptr, kOptionMachService},
 #endif  // BUILDFLAG(IS_APPLE)
+    {"enable-large-attachments",
+     no_argument,
+     nullptr,
+     kOptionEnableLargeAttachments},
     {"metrics-dir", required_argument, nullptr, kOptionMetrics},
     {"monitor-self", no_argument, nullptr, kOptionMonitorSelf},
     {"monitor-self-annotation",
@@ -890,6 +903,10 @@ int HandlerMain(int argc,
       case kOptionMetrics: {
         options.metrics_dir = base::FilePath(
             ToolSupport::CommandLineArgumentToFilePathStringType(optarg));
+        break;
+      }
+      case kOptionEnableLargeAttachments: {
+        options.enable_large_attachments = true;
         break;
       }
       case kOptionMonitorSelf: {
@@ -1149,6 +1166,8 @@ int HandlerMain(int argc,
         options.identify_client_via_url;
     upload_thread_options.rate_limit = options.rate_limit;
     upload_thread_options.upload_gzip = options.upload_gzip;
+    upload_thread_options.enable_large_attachments =
+        options.enable_large_attachments;
     upload_thread_options.watch_pending_reports = options.periodic_tasks;
 
     upload_thread.Reset(new CrashReportUploadThread(

--- a/util/net/http_headers.h
+++ b/util/net/http_headers.h
@@ -15,6 +15,8 @@
 #ifndef CRASHPAD_UTIL_NET_HTTP_HEADERS_H_
 #define CRASHPAD_UTIL_NET_HTTP_HEADERS_H_
 
+#include <string.h>
+
 #include <map>
 #include <string>
 
@@ -31,6 +33,32 @@ constexpr char kContentLength[] = "Content-Length";
 
 //! \brief The header name `"Content-Encoding"`.
 constexpr char kContentEncoding[] = "Content-Encoding";
+
+//! \brief Compares HTTP header names as ASCII strings.
+//!
+//! HTTP header names are case-insensitive.
+inline bool HTTPHeaderNameEquals(const std::string& lhs, const char* rhs) {
+  if (lhs.size() != strlen(rhs)) {
+    return false;
+  }
+
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    char l = lhs[i];
+    if (l >= 'A' && l <= 'Z') {
+      l += 'a' - 'A';
+    }
+
+    char r = rhs[i];
+    if (r >= 'A' && r <= 'Z') {
+      r += 'a' - 'A';
+    }
+
+    if (l != r) {
+      return false;
+    }
+  }
+  return true;
+}
 
 }  // namespace crashpad
 

--- a/util/net/http_headers.h
+++ b/util/net/http_headers.h
@@ -15,10 +15,9 @@
 #ifndef CRASHPAD_UTIL_NET_HTTP_HEADERS_H_
 #define CRASHPAD_UTIL_NET_HTTP_HEADERS_H_
 
-#include <string.h>
-
 #include <map>
 #include <string>
+#include <string_view>
 
 namespace crashpad {
 
@@ -37,8 +36,8 @@ constexpr char kContentEncoding[] = "Content-Encoding";
 //! \brief Compares HTTP header names as ASCII strings.
 //!
 //! HTTP header names are case-insensitive.
-inline bool HTTPHeaderNameEquals(const std::string& lhs, const char* rhs) {
-  if (lhs.size() != strlen(rhs)) {
+inline bool HTTPHeaderNameEquals(std::string_view lhs, std::string_view rhs) {
+  if (lhs.size() != rhs.size()) {
     return false;
   }
 

--- a/util/net/http_multipart_builder.cc
+++ b/util/net/http_multipart_builder.cc
@@ -34,6 +34,9 @@ constexpr char kCRLF[] = "\r\n";
 
 constexpr char kBoundaryCRLF[] = "\r\n\r\n";
 
+constexpr char kAttachmentRefMime[] =
+    "application/vnd.sentry.attachment-ref+json";
+
 // Generates a random string suitable for use as a multipart boundary.
 std::string GenerateBoundaryString() {
   // RFC 2046 §5.1.1 says that the boundary string may be 1 to 70 characters
@@ -175,8 +178,15 @@ std::unique_ptr<HTTPBodyStream> HTTPMultipartBuilder::GetBodyStream() {
     header += base::StringPrintf("Content-Type: %s%s",
         attachment.content_type.c_str(), kBoundaryCRLF);
 #else
-     header += base::StringPrintf("; filename=\"%s\"%s",
-        attachment.filename.c_str(), kBoundaryCRLF);
+    if (attachment.content_type == kAttachmentRefMime) {
+      header += base::StringPrintf("; filename=\"%s\"%s",
+          attachment.filename.c_str(), kCRLF);
+      header += base::StringPrintf("Content-Type: %s%s",
+          attachment.content_type.c_str(), kBoundaryCRLF);
+    } else {
+      header += base::StringPrintf("; filename=\"%s\"%s",
+          attachment.filename.c_str(), kBoundaryCRLF);
+    }
 #endif
 
     streams.push_back(new StringHTTPBodyStream(header));

--- a/util/net/http_multipart_builder.cc
+++ b/util/net/http_multipart_builder.cc
@@ -175,7 +175,7 @@ std::unique_ptr<HTTPBodyStream> HTTPMultipartBuilder::GetBodyStream() {
     header += base::StringPrintf("Content-Type: %s%s",
         attachment.content_type.c_str(), kBoundaryCRLF);
 #else
-    header += base::StringPrintf("; filename=\"%s\"%s",
+     header += base::StringPrintf("; filename=\"%s\"%s",
         attachment.filename.c_str(), kBoundaryCRLF);
 #endif
 

--- a/util/net/http_multipart_builder.cc
+++ b/util/net/http_multipart_builder.cc
@@ -34,9 +34,6 @@ constexpr char kCRLF[] = "\r\n";
 
 constexpr char kBoundaryCRLF[] = "\r\n\r\n";
 
-constexpr char kAttachmentRefMime[] =
-    "application/vnd.sentry.attachment-ref+json";
-
 // Generates a random string suitable for use as a multipart boundary.
 std::string GenerateBoundaryString() {
   // RFC 2046 §5.1.1 says that the boundary string may be 1 to 70 characters
@@ -178,15 +175,8 @@ std::unique_ptr<HTTPBodyStream> HTTPMultipartBuilder::GetBodyStream() {
     header += base::StringPrintf("Content-Type: %s%s",
         attachment.content_type.c_str(), kBoundaryCRLF);
 #else
-    if (attachment.content_type == kAttachmentRefMime) {
-      header += base::StringPrintf("; filename=\"%s\"%s",
-          attachment.filename.c_str(), kCRLF);
-      header += base::StringPrintf("Content-Type: %s%s",
-          attachment.content_type.c_str(), kBoundaryCRLF);
-    } else {
-      header += base::StringPrintf("; filename=\"%s\"%s",
-          attachment.filename.c_str(), kBoundaryCRLF);
-    }
+    header += base::StringPrintf("; filename=\"%s\"%s",
+        attachment.filename.c_str(), kBoundaryCRLF);
 #endif
 
     streams.push_back(new StringHTTPBodyStream(header));

--- a/util/net/http_transport.cc
+++ b/util/net/http_transport.cc
@@ -24,8 +24,11 @@ HTTPTransport::HTTPTransport()
     : url_(),
       method_("POST"),
       headers_(),
+      response_headers_(),
       body_stream_(),
-      timeout_(15.0) {
+      timeout_(15.0),
+      expected_response_code_(0),
+      response_code_(0) {
 }
 
 HTTPTransport::~HTTPTransport() {
@@ -48,6 +51,10 @@ void HTTPTransport::SetHeader(const std::string& header,
   headers_[header] = value;
 }
 
+void HTTPTransport::SetExpectedResponseCode(int status_code) {
+  expected_response_code_ = status_code;
+}
+
 void HTTPTransport::SetBodyStream(std::unique_ptr<HTTPBodyStream> stream) {
   body_stream_ = std::move(stream);
 }
@@ -58,6 +65,27 @@ void HTTPTransport::SetTimeout(double timeout) {
 
 void HTTPTransport::SetRootCACertificatePath(const base::FilePath& cert) {
   root_ca_certificate_path_ = cert;
+}
+
+void HTTPTransport::ResetResponse() {
+  response_code_ = 0;
+  response_headers_.clear();
+}
+
+void HTTPTransport::SetResponseCode(int response_code) {
+  response_code_ = response_code;
+}
+
+void HTTPTransport::SetResponseHeader(const std::string& header,
+                                      const std::string& value) {
+  response_headers_[header] = value;
+}
+
+bool HTTPTransport::IsExpectedResponseCode(int response_code) const {
+  if (expected_response_code_ != 0) {
+    return response_code == expected_response_code_;
+  }
+  return response_code >= 200 && response_code <= 203;
 }
 
 }  // namespace crashpad

--- a/util/net/http_transport.cc
+++ b/util/net/http_transport.cc
@@ -26,7 +26,8 @@ HTTPTransport::HTTPTransport()
       headers_(),
       response_headers_(),
       body_stream_(),
-      timeout_(15.0),
+      connect_timeout_(15.0),
+      transfer_timeout_(15.0),
       expected_response_code_(0),
       response_code_(0) {
 }
@@ -60,7 +61,16 @@ void HTTPTransport::SetBodyStream(std::unique_ptr<HTTPBodyStream> stream) {
 }
 
 void HTTPTransport::SetTimeout(double timeout) {
-  timeout_ = timeout;
+  SetConnectTimeout(timeout);
+  SetTransferTimeout(timeout);
+}
+
+void HTTPTransport::SetConnectTimeout(double timeout) {
+  connect_timeout_ = timeout;
+}
+
+void HTTPTransport::SetTransferTimeout(double timeout) {
+  transfer_timeout_ = timeout;
 }
 
 void HTTPTransport::SetRootCACertificatePath(const base::FilePath& cert) {

--- a/util/net/http_transport.h
+++ b/util/net/http_transport.h
@@ -80,10 +80,22 @@ class HTTPTransport {
   //!     ownership.
   void SetBodyStream(std::unique_ptr<HTTPBodyStream> stream);
 
-  //! \brief Sets the timeout for the HTTP request. The default is 15 seconds.
+  //! \brief Sets the connect and transfer timeouts for the HTTP request. The
+  //!     default is 15 seconds.
   //!
   //! \param[in] timeout The request timeout, in seconds.
   void SetTimeout(double timeout);
+
+  //! \brief Sets the timeout for establishing the HTTP connection.
+  //!
+  //! \param[in] timeout The connect timeout, in seconds.
+  void SetConnectTimeout(double timeout);
+
+  //! \brief Sets the timeout for the HTTP transfer.
+  //!
+  //! \param[in] timeout The transfer timeout, in seconds. A value of `0`
+  //!     disables the transfer timeout where supported.
+  void SetTransferTimeout(double timeout);
 
   //! \brief Sets a certificate file to be used in lieu of the system CA cert
   //!     bundle.
@@ -122,7 +134,8 @@ class HTTPTransport {
   const std::string& method() const { return method_; }
   const HTTPHeaders& headers() const { return headers_; }
   HTTPBodyStream* body_stream() const { return body_stream_.get(); }
-  double timeout() const { return timeout_; }
+  double connect_timeout() const { return connect_timeout_; }
+  double transfer_timeout() const { return transfer_timeout_; }
   const base::FilePath& root_ca_certificate_path() const {
     return root_ca_certificate_path_;
   }
@@ -140,7 +153,8 @@ class HTTPTransport {
   HTTPHeaders headers_;
   HTTPHeaders response_headers_;
   std::unique_ptr<HTTPBodyStream> body_stream_;
-  double timeout_;
+  double connect_timeout_;
+  double transfer_timeout_;
   int expected_response_code_;
   int response_code_;
 };

--- a/util/net/http_transport.h
+++ b/util/net/http_transport.h
@@ -68,6 +68,12 @@ class HTTPTransport {
   //! \param[in] value The value to set for the header.
   void SetHeader(const std::string& header, const std::string& value);
 
+  //! \brief Sets the expected HTTP response status code.
+  //!
+  //! By default, response status codes in the range 200-203 are considered
+  //! successful.
+  void SetExpectedResponseCode(int status_code);
+
   //! \brief Sets the stream object from which to generate the HTTP body.
   //!
   //! \param[in] stream A HTTPBodyStream, of which this class will take
@@ -97,8 +103,16 @@ class HTTPTransport {
   //!     if the response body is not required.
   //!
   //! \return Whether or not the request was successful, defined as returning
-  //!     a HTTP status code in the range 200-203 (inclusive).
+  //!     the expected HTTP status code, or a status code in the range 200-203
+  //!     (inclusive) if no specific expected response code was set.
   virtual bool ExecuteSynchronously(std::string* response_body) = 0;
+
+  //! \brief The HTTP status code returned by the most recent completed request,
+  //!     or 0 if no response was received.
+  int response_code() const { return response_code_; }
+
+  //! \brief The response headers returned by the most recent completed request.
+  const HTTPHeaders& response_headers() const { return response_headers_; }
 
  protected:
   HTTPTransport();
@@ -113,14 +127,22 @@ class HTTPTransport {
     return root_ca_certificate_path_;
   }
 
+  void ResetResponse();
+  void SetResponseCode(int response_code);
+  void SetResponseHeader(const std::string& header, const std::string& value);
+  bool IsExpectedResponseCode(int response_code) const;
+
  private:
   std::string url_;
   std::string http_proxy_;
   std::string method_;
   base::FilePath root_ca_certificate_path_;
   HTTPHeaders headers_;
+  HTTPHeaders response_headers_;
   std::unique_ptr<HTTPBodyStream> body_stream_;
   double timeout_;
+  int expected_response_code_;
+  int response_code_;
 };
 
 }  // namespace crashpad

--- a/util/net/http_transport_libcurl.cc
+++ b/util/net/http_transport_libcurl.cc
@@ -407,9 +407,16 @@ bool HTTPTransportLibcurl::ExecuteSynchronously(std::string* response_body) {
   }
 
   constexpr int kMillisecondsPerSecond = 1E3;
-  TRY_CURL_EASY_SETOPT(curl.get(),
-                       CURLOPT_TIMEOUT_MS,
-                       static_cast<long>(timeout() * kMillisecondsPerSecond));
+  TRY_CURL_EASY_SETOPT(
+      curl.get(),
+      CURLOPT_CONNECTTIMEOUT_MS,
+      static_cast<long>(connect_timeout() * kMillisecondsPerSecond));
+  if (transfer_timeout() > 0) {
+    TRY_CURL_EASY_SETOPT(
+        curl.get(),
+        CURLOPT_TIMEOUT_MS,
+        static_cast<long>(transfer_timeout() * kMillisecondsPerSecond));
+  }
 
   // If the request body size is known ahead of time, a Content-Length header
   // field will be present. Store that to use as CURLOPT_POSTFIELDSIZE_LARGE,

--- a/util/net/http_transport_libcurl.cc
+++ b/util/net/http_transport_libcurl.cc
@@ -417,12 +417,16 @@ bool HTTPTransportLibcurl::ExecuteSynchronously(std::string* response_body) {
   // inform libcurl of the request body size. Otherwise, use Transfer-Encoding:
   // chunked, which does not require advance knowledge of the request body size.
   bool chunked = true;
+  bool has_content_type = false;
   size_t content_length;
   for (const auto& pair : headers()) {
-    if (pair.first == kContentLength) {
+    if (HTTPHeaderNameEquals(pair.first, kContentLength)) {
       chunked = !base::StringToSizeT(pair.second, &content_length);
       DCHECK(!chunked);
     } else {
+      if (HTTPHeaderNameEquals(pair.first, kContentType)) {
+        has_content_type = true;
+      }
       TRY_CURL_SLIST_APPEND(curl_headers,
                             (pair.first + ": " + pair.second).c_str());
     }
@@ -439,6 +443,13 @@ bool HTTPTransportLibcurl::ExecuteSynchronously(std::string* response_body) {
     // The drawback is that certain HTTP error statuses may not be received
     // until after substantial amounts of data have been sent to the server.
     TRY_CURL_SLIST_APPEND(curl_headers, "Expect:");
+
+    // CURLOPT_POST adds application/x-www-form-urlencoded when no Content-Type
+    // is provided. Some POST requests, such as TUS creation, intentionally send
+    // no Content-Type.
+    if (method() == "POST" && !has_content_type) {
+      TRY_CURL_SLIST_APPEND(curl_headers, "Content-Type:");
+    }
   }
 
   if (method() == "POST") {

--- a/util/net/http_transport_libcurl.cc
+++ b/util/net/http_transport_libcurl.cc
@@ -428,11 +428,9 @@ bool HTTPTransportLibcurl::ExecuteSynchronously(std::string* response_body) {
     }
   }
 
-  if (method() == "POST") {
-    TRY_CURL_EASY_SETOPT(curl.get(), CURLOPT_POST, 1l);
-
-    // By default when sending a POST request, libcurl includes an “Expect:
-    // 100-continue” header field. Althogh this header is specified in HTTP/1.1
+  if (method() != "GET") {
+    // By default when sending a request body, libcurl may include an “Expect:
+    // 100-continue” header field. Although this header is specified in HTTP/1.1
     // (RFC 2616 §8.2.3, RFC 7231 §5.1.1), even collection servers that claim to
     // speak HTTP/1.1 may not respond to it. When sending this header field,
     // libcurl will wait for one second for the server to respond with a “100
@@ -441,6 +439,10 @@ bool HTTPTransportLibcurl::ExecuteSynchronously(std::string* response_body) {
     // The drawback is that certain HTTP error statuses may not be received
     // until after substantial amounts of data have been sent to the server.
     TRY_CURL_SLIST_APPEND(curl_headers, "Expect:");
+  }
+
+  if (method() == "POST") {
+    TRY_CURL_EASY_SETOPT(curl.get(), CURLOPT_POST, 1l);
 
     if (chunked) {
       TRY_CURL_SLIST_APPEND(curl_headers, "Transfer-Encoding: chunked");

--- a/util/net/http_transport_libcurl.cc
+++ b/util/net/http_transport_libcurl.cc
@@ -600,7 +600,8 @@ size_t HTTPTransportLibcurl::WriteResponseHeader(char* buffer,
                                                  void* userdata) {
   HTTPTransportLibcurl* self =
       reinterpret_cast<HTTPTransportLibcurl*>(userdata);
-  const size_t len = size * nitems;
+  base::CheckedNumeric<size_t> checked_len = base::CheckMul(size, nitems);
+  size_t len = checked_len.ValueOrDefault(std::numeric_limits<size_t>::max());
   std::string line(buffer, len);
   while (!line.empty() && (line.back() == '\r' || line.back() == '\n')) {
     line.pop_back();

--- a/util/net/http_transport_libcurl.cc
+++ b/util/net/http_transport_libcurl.cc
@@ -338,6 +338,10 @@ class HTTPTransportLibcurl final : public HTTPTransport {
                                   size_t size,
                                   size_t nitems,
                                   void* userdata);
+  static size_t WriteResponseHeader(char* buffer,
+                                    size_t size,
+                                    size_t nitems,
+                                    void* userdata);
 };
 
 HTTPTransportLibcurl::HTTPTransportLibcurl() : HTTPTransport() {}
@@ -347,7 +351,10 @@ HTTPTransportLibcurl::~HTTPTransportLibcurl() {}
 bool HTTPTransportLibcurl::ExecuteSynchronously(std::string* response_body) {
   DCHECK(body_stream());
 
-  response_body->clear();
+  ResetResponse();
+  if (response_body) {
+    response_body->clear();
+  }
 
   // curl_easy_init() will do this on the first call if it hasn’t been done yet,
   // but not in a thread-safe way as is done here.
@@ -448,8 +455,21 @@ bool HTTPTransportLibcurl::ExecuteSynchronously(std::string* response_body) {
           curl.get(), CURLOPT_POSTFIELDSIZE_LARGE, content_length_curl);
     }
   } else if (method() != "GET") {
-    // Untested.
     TRY_CURL_EASY_SETOPT(curl.get(), CURLOPT_CUSTOMREQUEST, method().c_str());
+    TRY_CURL_EASY_SETOPT(curl.get(), CURLOPT_UPLOAD, 1l);
+
+    if (chunked) {
+      TRY_CURL_SLIST_APPEND(curl_headers, "Transfer-Encoding: chunked");
+    } else {
+      curl_off_t content_length_curl;
+      if (!AssignIfInRange(&content_length_curl, content_length)) {
+        LOG(ERROR) << base::StringPrintf("Content-Length %zu too large",
+                                         content_length);
+        return false;
+      }
+      TRY_CURL_EASY_SETOPT(
+          curl.get(), CURLOPT_INFILESIZE_LARGE, content_length_curl);
+    }
   }
 
   TRY_CURL_EASY_SETOPT(curl.get(), CURLOPT_HTTPHEADER, curl_headers.get());
@@ -458,6 +478,8 @@ bool HTTPTransportLibcurl::ExecuteSynchronously(std::string* response_body) {
   TRY_CURL_EASY_SETOPT(curl.get(), CURLOPT_READDATA, this);
   TRY_CURL_EASY_SETOPT(curl.get(), CURLOPT_WRITEFUNCTION, WriteResponseBody);
   TRY_CURL_EASY_SETOPT(curl.get(), CURLOPT_WRITEDATA, response_body);
+  TRY_CURL_EASY_SETOPT(curl.get(), CURLOPT_HEADERFUNCTION, WriteResponseHeader);
+  TRY_CURL_EASY_SETOPT(curl.get(), CURLOPT_HEADERDATA, this);
   if (!http_proxy().empty()) {
     // An empty string is a special value that libcurl interprets as “no proxy”.
     const char* proxy = http_proxy() == "<empty>" ? "" : http_proxy().c_str();
@@ -486,9 +508,11 @@ bool HTTPTransportLibcurl::ExecuteSynchronously(std::string* response_body) {
     return false;
   }
 
-  if (status != 200) {
+  SetResponseCode(static_cast<int>(status));
+  if (!IsExpectedResponseCode(static_cast<int>(status))) {
+    const char* body = response_body ? response_body->c_str() : "";
     LOG(ERROR) << base::StringPrintf(
-        "HTTP status %ld, response = \"%s\"", status, response_body->c_str());
+        "HTTP status %ld, response = \"%s\"", status, body);
     return false;
   }
 
@@ -541,7 +565,34 @@ size_t HTTPTransportLibcurl::WriteResponseBody(char* buffer,
   base::CheckedNumeric<size_t> checked_len = base::CheckMul(size, nitems);
   size_t len = checked_len.ValueOrDefault(std::numeric_limits<size_t>::max());
 
+  if (!response_body) {
+    return len;
+  }
+
   response_body->append(buffer, len);
+  return len;
+}
+
+// static
+size_t HTTPTransportLibcurl::WriteResponseHeader(char* buffer,
+                                                 size_t size,
+                                                 size_t nitems,
+                                                 void* userdata) {
+  HTTPTransportLibcurl* self =
+      reinterpret_cast<HTTPTransportLibcurl*>(userdata);
+  const size_t len = size * nitems;
+  std::string line(buffer, len);
+  while (!line.empty() && (line.back() == '\r' || line.back() == '\n')) {
+    line.pop_back();
+  }
+
+  const size_t separator = line.find(':');
+  if (separator != std::string::npos) {
+    std::string value = line.substr(separator + 1);
+    const size_t first = value.find_first_not_of(" \t");
+    value = first == std::string::npos ? std::string() : value.substr(first);
+    self->SetResponseHeader(line.substr(0, separator), value);
+  }
   return len;
 }
 

--- a/util/net/http_transport_mac.mm
+++ b/util/net/http_transport_mac.mm
@@ -17,6 +17,8 @@
 #import <Foundation/Foundation.h>
 #include <sys/utsname.h>
 
+#include <limits>
+
 #include "base/apple/bridging.h"
 #include "base/apple/foundation_util.h"
 #include "base/strings/stringprintf.h"
@@ -197,6 +199,14 @@ NSString* UserAgentString() {
   }
 
   return user_agent;
+}
+
+NSTimeInterval RequestTimeoutInterval(double transfer_timeout) {
+  if (transfer_timeout > 0) {
+    return transfer_timeout;
+  }
+  // NSURLRequest has no disabled timeout sentinel.
+  return std::numeric_limits<NSTimeInterval>::max();
 }
 
 class HTTPTransportMac final : public HTTPTransport {
@@ -391,9 +401,8 @@ bool HTTPTransportMac::ExecuteSynchronously(std::string* response_body) {
     NSMutableURLRequest* request =
         [NSMutableURLRequest requestWithURL:url
                                 cachePolicy:NSURLRequestUseProtocolCachePolicy
-                            timeoutInterval:transfer_timeout() > 0
-                                                ? transfer_timeout()
-                                                : connect_timeout()];
+                            timeoutInterval:RequestTimeoutInterval(
+                                                transfer_timeout())];
     [request setHTTPMethod:base::SysUTF8ToNSString(method())];
 
     // If left to its own devices, CFNetwork would build a user-agent string

--- a/util/net/http_transport_mac.mm
+++ b/util/net/http_transport_mac.mm
@@ -211,6 +211,7 @@ class HTTPTransportMac final : public HTTPTransport {
   bool ExecuteSynchronously(std::string* response_body) override;
 
  private:
+  void SetResponseHeaders(NSHTTPURLResponse* response);
   bool ExecuteNormalRequest(NSMutableURLRequest* request,
                             std::string* response_body);
   bool ExecuteProxyRequest(NSMutableURLRequest* request,
@@ -221,6 +222,15 @@ class HTTPTransportMac final : public HTTPTransport {
 HTTPTransportMac::HTTPTransportMac() : HTTPTransport() {}
 
 HTTPTransportMac::~HTTPTransportMac() = default;
+
+void HTTPTransportMac::SetResponseHeaders(NSHTTPURLResponse* response) {
+  NSDictionary* headers = [response allHeaderFields];
+  for (NSString* name in headers) {
+    NSString* value = [headers objectForKey:name];
+    SetResponseHeader(base::SysNSStringToUTF8(name),
+                      base::SysNSStringToUTF8(value));
+  }
+}
 
 bool HTTPTransportMac::ExecuteNormalRequest(NSMutableURLRequest* request,
                                             std::string* response_body) {
@@ -254,11 +264,7 @@ bool HTTPTransportMac::ExecuteNormalRequest(NSMutableURLRequest* request,
     }
     NSInteger http_status = [http_response statusCode];
     SetResponseCode(implicit_cast<int>(http_status));
-    NSString* location =
-        [[http_response allHeaderFields] objectForKey:@"Location"];
-    if (location) {
-      SetResponseHeader("Location", [location UTF8String]);
-    }
+    SetResponseHeaders(http_response);
     if (!IsExpectedResponseCode(implicit_cast<int>(http_status))) {
       LOG(ERROR) << base::StringPrintf("HTTP status %ld",
                                        implicit_cast<long>(http_status));
@@ -340,11 +346,7 @@ bool HTTPTransportMac::ExecuteProxyRequest(NSMutableURLRequest* request,
             }
             NSInteger http_status = [http_response statusCode];
             SetResponseCode(implicit_cast<int>(http_status));
-            NSString* location =
-                [[http_response allHeaderFields] objectForKey:@"Location"];
-            if (location) {
-              SetResponseHeader("Location", [location UTF8String]);
-            }
+            SetResponseHeaders(http_response);
             if (!IsExpectedResponseCode(implicit_cast<int>(http_status))) {
               LOG(ERROR) << base::StringPrintf(
                   "HTTP status %ld", implicit_cast<long>(http_status));

--- a/util/net/http_transport_mac.mm
+++ b/util/net/http_transport_mac.mm
@@ -210,6 +210,17 @@ NSTimeInterval RequestIdleTimeoutInterval(double connect_timeout,
   return connect_timeout;
 }
 
+void AssignResponseBody(NSData* body, std::string* response_body) {
+  if (!response_body) {
+    return;
+  }
+  response_body->clear();
+  if ([body length] > 0) {
+    response_body->assign(static_cast<const char*>([body bytes]),
+                          [body length]);
+  }
+}
+
 class HTTPTransportMac final : public HTTPTransport {
  public:
   HTTPTransportMac();
@@ -276,15 +287,11 @@ bool HTTPTransportMac::ExecuteNormalRequest(NSMutableURLRequest* request,
     NSInteger http_status = [http_response statusCode];
     SetResponseCode(implicit_cast<int>(http_status));
     SetResponseHeaders(http_response);
+    AssignResponseBody(body, response_body);
     if (!IsExpectedResponseCode(implicit_cast<int>(http_status))) {
       LOG(ERROR) << base::StringPrintf("HTTP status %ld",
                                        implicit_cast<long>(http_status));
       return false;
-    }
-
-    if (response_body) {
-      response_body->assign(static_cast<const char*>([body bytes]),
-                            [body length]);
     }
 
     return true;
@@ -358,6 +365,7 @@ bool HTTPTransportMac::ExecuteProxyRequest(NSMutableURLRequest* request,
             NSInteger http_status = [http_response statusCode];
             SetResponseCode(implicit_cast<int>(http_status));
             SetResponseHeaders(http_response);
+            AssignResponseBody(body, response_body);
             if (!IsExpectedResponseCode(implicit_cast<int>(http_status))) {
               LOG(ERROR) << base::StringPrintf(
                   "HTTP status %ld", implicit_cast<long>(http_status));
@@ -366,10 +374,6 @@ bool HTTPTransportMac::ExecuteProxyRequest(NSMutableURLRequest* request,
               return;
             }
 
-            if (response_body) {
-              response_body->assign(static_cast<const char*>([body bytes]),
-                                    [body length]);
-            }
             sync_rv = true;
             dispatch_semaphore_signal(semaphore);
           }];
@@ -414,14 +418,20 @@ bool HTTPTransportMac::ExecuteSynchronously(std::string* response_body) {
     // Info.plist-derived strings.
     [request setValue:UserAgentString() forHTTPHeaderField:@"User-Agent"];
 
+    bool has_empty_body = false;
     for (const auto& pair : headers()) {
+      if (HTTPHeaderNameEquals(pair.first, kContentLength)) {
+        has_empty_body = pair.second == "0";
+      }
       [request setValue:base::SysUTF8ToNSString(pair.second)
           forHTTPHeaderField:base::SysUTF8ToNSString(pair.first)];
     }
 
-    NSInputStream* input_stream = [[CrashpadHTTPBodyStreamTransport alloc]
-        initWithBodyStream:body_stream()];
-    [request setHTTPBodyStream:input_stream];
+    if (!has_empty_body) {
+      NSInputStream* input_stream = [[CrashpadHTTPBodyStreamTransport alloc]
+          initWithBodyStream:body_stream()];
+      [request setHTTPBodyStream:input_stream];
+    }
 
     if (http_proxy().empty()) {
       return ExecuteNormalRequest(request, response_body);

--- a/util/net/http_transport_mac.mm
+++ b/util/net/http_transport_mac.mm
@@ -211,11 +211,11 @@ class HTTPTransportMac final : public HTTPTransport {
   bool ExecuteSynchronously(std::string* response_body) override;
 
  private:
-  static bool ExecuteNormalRequest(NSMutableURLRequest* request,
-                                   std::string* response_body);
-  static bool ExecuteProxyRequest(NSMutableURLRequest* request,
-                                  const std::string& proxy,
-                                  std::string* response_body);
+  bool ExecuteNormalRequest(NSMutableURLRequest* request,
+                            std::string* response_body);
+  bool ExecuteProxyRequest(NSMutableURLRequest* request,
+                           const std::string& proxy,
+                           std::string* response_body);
 };
 
 HTTPTransportMac::HTTPTransportMac() : HTTPTransport() {}
@@ -253,7 +253,13 @@ bool HTTPTransportMac::ExecuteNormalRequest(NSMutableURLRequest* request,
       return false;
     }
     NSInteger http_status = [http_response statusCode];
-    if (http_status < 200 || http_status > 203) {
+    SetResponseCode(implicit_cast<int>(http_status));
+    NSString* location =
+        [[http_response allHeaderFields] objectForKey:@"Location"];
+    if (location) {
+      SetResponseHeader("Location", [location UTF8String]);
+    }
+    if (!IsExpectedResponseCode(implicit_cast<int>(http_status))) {
       LOG(ERROR) << base::StringPrintf("HTTP status %ld",
                                        implicit_cast<long>(http_status));
       return false;
@@ -333,7 +339,13 @@ bool HTTPTransportMac::ExecuteProxyRequest(NSMutableURLRequest* request,
               return;
             }
             NSInteger http_status = [http_response statusCode];
-            if (http_status < 200 || http_status > 203) {
+            SetResponseCode(implicit_cast<int>(http_status));
+            NSString* location =
+                [[http_response allHeaderFields] objectForKey:@"Location"];
+            if (location) {
+              SetResponseHeader("Location", [location UTF8String]);
+            }
+            if (!IsExpectedResponseCode(implicit_cast<int>(http_status))) {
               LOG(ERROR) << base::StringPrintf(
                   "HTTP status %ld", implicit_cast<long>(http_status));
               sync_rv = false;
@@ -368,6 +380,8 @@ bool HTTPTransportMac::ExecuteProxyRequest(NSMutableURLRequest* request,
 
 bool HTTPTransportMac::ExecuteSynchronously(std::string* response_body) {
   DCHECK(body_stream());
+
+  ResetResponse();
 
   @autoreleasepool {
     NSString* url_ns_string = base::SysUTF8ToNSString(url());

--- a/util/net/http_transport_mac.mm
+++ b/util/net/http_transport_mac.mm
@@ -17,8 +17,6 @@
 #import <Foundation/Foundation.h>
 #include <sys/utsname.h>
 
-#include <limits>
-
 #include "base/apple/bridging.h"
 #include "base/apple/foundation_util.h"
 #include "base/strings/stringprintf.h"
@@ -201,12 +199,15 @@ NSString* UserAgentString() {
   return user_agent;
 }
 
-NSTimeInterval RequestTimeoutInterval(double transfer_timeout) {
+NSTimeInterval RequestIdleTimeoutInterval(double connect_timeout,
+                                          double transfer_timeout) {
   if (transfer_timeout > 0) {
     return transfer_timeout;
   }
-  // NSURLRequest has no disabled timeout sentinel.
-  return std::numeric_limits<NSTimeInterval>::max();
+  // NSURLRequest exposes one idle timeout, not separate connect and transfer
+  // timeouts. Keep the configured idle guard when callers disable the transfer
+  // timeout for backends that support that distinction.
+  return connect_timeout;
 }
 
 class HTTPTransportMac final : public HTTPTransport {
@@ -401,7 +402,8 @@ bool HTTPTransportMac::ExecuteSynchronously(std::string* response_body) {
     NSMutableURLRequest* request =
         [NSMutableURLRequest requestWithURL:url
                                 cachePolicy:NSURLRequestUseProtocolCachePolicy
-                            timeoutInterval:RequestTimeoutInterval(
+                            timeoutInterval:RequestIdleTimeoutInterval(
+                                                connect_timeout(),
                                                 transfer_timeout())];
     [request setHTTPMethod:base::SysUTF8ToNSString(method())];
 

--- a/util/net/http_transport_mac.mm
+++ b/util/net/http_transport_mac.mm
@@ -391,7 +391,9 @@ bool HTTPTransportMac::ExecuteSynchronously(std::string* response_body) {
     NSMutableURLRequest* request =
         [NSMutableURLRequest requestWithURL:url
                                 cachePolicy:NSURLRequestUseProtocolCachePolicy
-                            timeoutInterval:timeout()];
+                            timeoutInterval:transfer_timeout() > 0
+                                                ? transfer_timeout()
+                                                : connect_timeout()];
     [request setHTTPMethod:base::SysUTF8ToNSString(method())];
 
     // If left to its own devices, CFNetwork would build a user-agent string

--- a/util/net/http_transport_socket.cc
+++ b/util/net/http_transport_socket.cc
@@ -515,6 +515,11 @@ bool ReadContentChunked(Stream* stream, std::string* body) {
   return false;
 }
 
+bool ResponseHasBody(int http_status) {
+  return (http_status < 100 || http_status >= 200) && http_status != 204 &&
+         http_status != 205 && http_status != 304;
+}
+
 bool ReadResponse(Stream* stream,
                   std::string* response_body,
                   int* http_status,
@@ -535,18 +540,19 @@ bool ReadResponse(Stream* stream,
   }
   *response_headers = headers;
 
+  if (!ResponseHasBody(*http_status)) {
+    return true;
+  }
+
   auto it = headers.find("Content-Length");
-  size_t len = 0;
   if (it != headers.end()) {
+    size_t len = 0;
     if (!base::StringToSizeT(it->second, &len)) {
       LOG(ERROR) << "invalid Content-Length";
       return false;
     }
-  }
-
-  if (len) {
     response_body->resize(len, 0);
-    return stream->LoggingRead(&(*response_body)[0], len);
+    return len == 0 || stream->LoggingRead(&(*response_body)[0], len);
   }
 
   it = headers.find("Transfer-Encoding");

--- a/util/net/http_transport_socket.cc
+++ b/util/net/http_transport_socket.cc
@@ -32,6 +32,7 @@
 #include "util/net/http_body.h"
 #include "util/net/http_transport.h"
 #include "util/net/url.h"
+#include "util/numeric/safe_assignment.h"
 #include "util/stdlib/string_number_conversion.h"
 #include "util/string/split_string.h"
 
@@ -463,7 +464,7 @@ bool StartsWith(const std::string& str, const char* with, size_t len) {
   return str.compare(0, len, with) == 0;
 }
 
-bool ReadResponseLine(Stream* stream) {
+bool ReadResponseLine(Stream* stream, int* http_status) {
   std::string response_line;
   if (!ReadLine(stream, &response_line)) {
     LOG(ERROR) << "ReadLine";
@@ -477,10 +478,10 @@ bool ReadResponseLine(Stream* stream) {
       response_line.at(strlen(kHttp10) + 3) != ' ') {
     return false;
   }
-  unsigned int http_status = 0;
+  unsigned int status = 0;
   return base::StringToUint(response_line.substr(strlen(kHttp10), 3),
-                            &http_status) &&
-         http_status >= 200 && http_status <= 203;
+                            &status) &&
+         AssignIfInRange(http_status, status);
 }
 
 bool ReadResponseHeaders(Stream* stream, HTTPHeaders* headers) {
@@ -514,21 +515,29 @@ bool ReadContentChunked(Stream* stream, std::string* body) {
   return false;
 }
 
-bool ReadResponse(Stream* stream, std::string* response_body) {
+bool ReadResponse(Stream* stream,
+                  std::string* response_body,
+                  int* http_status,
+                  HTTPHeaders* response_headers) {
+  std::string ignored_response_body;
+  if (!response_body) {
+    response_body = &ignored_response_body;
+  }
   response_body->clear();
 
-  if (!ReadResponseLine(stream)) {
+  if (!ReadResponseLine(stream, http_status)) {
     return false;
   }
 
-  HTTPHeaders response_headers;
-  if (!ReadResponseHeaders(stream, &response_headers)) {
+  HTTPHeaders headers;
+  if (!ReadResponseHeaders(stream, &headers)) {
     return false;
   }
+  *response_headers = headers;
 
-  auto it = response_headers.find("Content-Length");
+  auto it = headers.find("Content-Length");
   size_t len = 0;
-  if (it != response_headers.end()) {
+  if (it != headers.end()) {
     if (!base::StringToSizeT(it->second, &len)) {
       LOG(ERROR) << "invalid Content-Length";
       return false;
@@ -540,9 +549,9 @@ bool ReadResponse(Stream* stream, std::string* response_body) {
     return stream->LoggingRead(&(*response_body)[0], len);
   }
 
-  it = response_headers.find("Transfer-Encoding");
+  it = headers.find("Transfer-Encoding");
   bool chunked = false;
-  if (it != response_headers.end() && it->second == "chunked") {
+  if (it != headers.end() && it->second == "chunked") {
     chunked = true;
   }
 
@@ -551,6 +560,8 @@ bool ReadResponse(Stream* stream, std::string* response_body) {
 }
 
 bool HTTPTransportSocket::ExecuteSynchronously(std::string* response_body) {
+  ResetResponse();
+
   std::string scheme, hostname, port, resource;
   if (!CrackURL(url(), &scheme, &hostname, &port, &resource)) {
     return false;
@@ -592,7 +603,18 @@ bool HTTPTransportSocket::ExecuteSynchronously(std::string* response_body) {
     return false;
   }
 
-  if (!ReadResponse(stream.get(), response_body)) {
+  int http_status = 0;
+  HTTPHeaders response_headers;
+  if (!ReadResponse(
+          stream.get(), response_body, &http_status, &response_headers)) {
+    return false;
+  }
+  SetResponseCode(http_status);
+  for (const auto& response_header : response_headers) {
+    SetResponseHeader(response_header.first, response_header.second);
+  }
+  if (!IsExpectedResponseCode(http_status)) {
+    LOG(ERROR) << base::StringPrintf("HTTP status %d", http_status);
     return false;
   }
 

--- a/util/net/http_transport_socket.cc
+++ b/util/net/http_transport_socket.cc
@@ -605,13 +605,14 @@ bool HTTPTransportSocket::ExecuteSynchronously(std::string* response_body) {
 
   int http_status = 0;
   HTTPHeaders response_headers;
-  if (!ReadResponse(
-          stream.get(), response_body, &http_status, &response_headers)) {
-    return false;
-  }
+  const bool response_read =
+      ReadResponse(stream.get(), response_body, &http_status, &response_headers);
   SetResponseCode(http_status);
   for (const auto& response_header : response_headers) {
     SetResponseHeader(response_header.first, response_header.second);
+  }
+  if (!response_read) {
+    return false;
   }
   if (!IsExpectedResponseCode(http_status)) {
     LOG(ERROR) << base::StringPrintf("HTTP status %d", http_status);

--- a/util/net/http_transport_win.cc
+++ b/util/net/http_transport_win.cc
@@ -139,11 +139,62 @@ class HTTPTransportWin final : public HTTPTransport {
   ~HTTPTransportWin() override;
 
   bool ExecuteSynchronously(std::string* response_body) override;
+
+ private:
+  void SetResponseHeaders(HINTERNET request);
 };
 
 HTTPTransportWin::HTTPTransportWin() : HTTPTransport() {}
 
 HTTPTransportWin::~HTTPTransportWin() {}
+
+void HTTPTransportWin::SetResponseHeaders(HINTERNET request) {
+  DWORD headers_size = 0;
+  if (WinHttpQueryHeaders(request,
+                          WINHTTP_QUERY_RAW_HEADERS_CRLF,
+                          WINHTTP_HEADER_NAME_BY_INDEX,
+                          WINHTTP_NO_OUTPUT_BUFFER,
+                          &headers_size,
+                          WINHTTP_NO_HEADER_INDEX) ||
+      GetLastError() != ERROR_INSUFFICIENT_BUFFER) {
+    return;
+  }
+
+  std::wstring headers(headers_size / sizeof(wchar_t), L'\0');
+  if (!WinHttpQueryHeaders(request,
+                           WINHTTP_QUERY_RAW_HEADERS_CRLF,
+                           WINHTTP_HEADER_NAME_BY_INDEX,
+                           &headers[0],
+                           &headers_size,
+                           WINHTTP_NO_HEADER_INDEX)) {
+    return;
+  }
+  headers.resize(wcslen(headers.c_str()));
+
+  size_t line_start = 0;
+  while (line_start < headers.size()) {
+    size_t line_end = headers.find(L"\r\n", line_start);
+    if (line_end == std::wstring::npos) {
+      line_end = headers.size();
+    }
+    if (line_end == line_start) {
+      break;
+    }
+
+    std::wstring line = headers.substr(line_start, line_end - line_start);
+    size_t separator = line.find(L':');
+    if (separator != std::wstring::npos) {
+      std::wstring value = line.substr(separator + 1);
+      const size_t first = value.find_first_not_of(L" \t");
+      value =
+          first == std::wstring::npos ? std::wstring() : value.substr(first);
+      SetResponseHeader(base::WideToUTF8(line.substr(0, separator)),
+                        base::WideToUTF8(value));
+    }
+
+    line_start = line_end + 2;
+  }
+}
 
 bool HTTPTransportWin::ExecuteSynchronously(std::string* response_body) {
   ResetResponse();
@@ -410,26 +461,7 @@ bool HTTPTransportWin::ExecuteSynchronously(std::string* response_body) {
   }
 
   SetResponseCode(static_cast<int>(status_code));
-
-  DWORD location_size = 0;
-  if (!WinHttpQueryHeaders(request.get(),
-                           WINHTTP_QUERY_LOCATION,
-                           WINHTTP_HEADER_NAME_BY_INDEX,
-                           WINHTTP_NO_OUTPUT_BUFFER,
-                           &location_size,
-                           WINHTTP_NO_HEADER_INDEX) &&
-      GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
-    std::wstring location(location_size / sizeof(wchar_t), L'\0');
-    if (WinHttpQueryHeaders(request.get(),
-                            WINHTTP_QUERY_LOCATION,
-                            WINHTTP_HEADER_NAME_BY_INDEX,
-                            &location[0],
-                            &location_size,
-                            WINHTTP_NO_HEADER_INDEX)) {
-      location.resize(wcslen(location.c_str()));
-      SetResponseHeader("Location", base::WideToUTF8(location));
-    }
-  }
+  SetResponseHeaders(request.get());
 
   if (!IsExpectedResponseCode(static_cast<int>(status_code))) {
     LOG(ERROR) << base::StringPrintf("HTTP status %lu", status_code);

--- a/util/net/http_transport_win.cc
+++ b/util/net/http_transport_win.cc
@@ -239,12 +239,13 @@ bool HTTPTransportWin::ExecuteSynchronously(std::string* response_body) {
     return false;
   }
 
-  int timeout_in_ms = static_cast<int>(timeout() * 1000);
+  int connect_timeout_in_ms = static_cast<int>(connect_timeout() * 1000);
+  int transfer_timeout_in_ms = static_cast<int>(transfer_timeout() * 1000);
   if (!WinHttpSetTimeouts(session.get(),
-                          timeout_in_ms,
-                          timeout_in_ms,
-                          timeout_in_ms,
-                          timeout_in_ms)) {
+                          connect_timeout_in_ms,
+                          connect_timeout_in_ms,
+                          transfer_timeout_in_ms,
+                          transfer_timeout_in_ms)) {
     LOG(ERROR) << WinHttpMessage("WinHttpSetTimeouts");
     return false;
   }

--- a/util/net/http_transport_win.cc
+++ b/util/net/http_transport_win.cc
@@ -146,6 +146,8 @@ HTTPTransportWin::HTTPTransportWin() : HTTPTransport() {}
 HTTPTransportWin::~HTTPTransportWin() {}
 
 bool HTTPTransportWin::ExecuteSynchronously(std::string* response_body) {
+  ResetResponse();
+
   // ensure the proxy starts with `http://`, otherwise ignore it
   const char proto[] = "http://";
   ScopedHINTERNET session;
@@ -407,7 +409,29 @@ bool HTTPTransportWin::ExecuteSynchronously(std::string* response_body) {
     return false;
   }
 
-  if (status_code < 200 || status_code > 203) {
+  SetResponseCode(static_cast<int>(status_code));
+
+  DWORD location_size = 0;
+  if (!WinHttpQueryHeaders(request.get(),
+                           WINHTTP_QUERY_LOCATION,
+                           WINHTTP_HEADER_NAME_BY_INDEX,
+                           WINHTTP_NO_OUTPUT_BUFFER,
+                           &location_size,
+                           WINHTTP_NO_HEADER_INDEX) &&
+      GetLastError() == ERROR_INSUFFICIENT_BUFFER) {
+    std::wstring location(location_size / sizeof(wchar_t), L'\0');
+    if (WinHttpQueryHeaders(request.get(),
+                            WINHTTP_QUERY_LOCATION,
+                            WINHTTP_HEADER_NAME_BY_INDEX,
+                            &location[0],
+                            &location_size,
+                            WINHTTP_NO_HEADER_INDEX)) {
+      location.resize(wcslen(location.c_str()));
+      SetResponseHeader("Location", base::WideToUTF8(location));
+    }
+  }
+
+  if (!IsExpectedResponseCode(static_cast<int>(status_code))) {
     LOG(ERROR) << base::StringPrintf("HTTP status %lu", status_code);
     return false;
   }


### PR DESCRIPTION
Required for / tested by:
- https://github.com/getsentry/sentry-native/pull/1674

Examples with [inflated](https://github.com/getsentry/crashpad/commit/5f5b720b59ace24cf9fdd94b504f94b2260c9f27) ~128MB minidumps:
- [Windows](https://sentry-sdks.sentry.io/issues/7446554613/?environment=playground&project=4506178389999616)
- [macOS](https://sentry-sdks.sentry.io/issues/7438614928/?environment=playground&project=4506178389999616)
- [Linux](https://sentry-sdks.sentry.io/issues/7446453629/?environment=playground&project=4506178389999616)

<img width="875" height="191" alt="image" src="https://github.com/user-attachments/assets/030a53c9-e1c7-44e6-ae6f-daa20b116539" />


Also, downloads from Sentry have been verified to match:
```sh
$ sha256sum .sentry-native/completed/5988aa84-b912-4784-4d57-3e9cabc15227.dmp
5f173c73c9cc42b57f93694fc191c53721a1b9d681e4234df252f0df5a693977

$ sha256sum ~/Downloads/5988aa84-b912-4784-4d57-3e9cabc15227.dmp
5f173c73c9cc42b57f93694fc191c53721a1b9d681e4234df252f0df5a693977
```