### PR TITLE
feat(mac): wait-for-upload macOS support

### DIFF
--- a/client/crashpad_client_mac.cc
+++ b/client/crashpad_client_mac.cc
@@ -143,6 +143,7 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
       const base::FilePath& crash_reporter,
       const base::FilePath& crash_envelope,
       const std::string& report_id,
+      bool wait_for_upload,
       bool restartable) {
     base::apple::ScopedMachReceiveRight receive_right(
         NewMachPort(MACH_PORT_RIGHT_RECEIVE));
@@ -187,6 +188,7 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
                      crash_reporter,
                      crash_envelope,
                      report_id,
+                     wait_for_upload,
                      std::move(receive_right),
                      handler_restarter.get(),
                      false)) {
@@ -204,7 +206,8 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
                                               attachments,
                                               crash_reporter,
                                               crash_envelope,
-                                              report_id)) {
+                                              report_id,
+                                              wait_for_upload)) {
       // The thread owns the object now.
       std::ignore = handler_restarter.release();
     }
@@ -244,6 +247,7 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
                 crash_reporter_,
                 crash_envelope_,
                 report_id_,
+                wait_for_upload_,
                 base::apple::ScopedMachReceiveRight(rights),
                 this,
                 true);
@@ -264,6 +268,7 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
         crash_reporter_(),
         crash_envelope_(),
         report_id_(),
+        wait_for_upload_(false),
         notify_port_(NewMachPort(MACH_PORT_RIGHT_RECEIVE)),
         last_start_time_(0) {}
 
@@ -297,6 +302,7 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
                           const base::FilePath& crash_reporter,
                           const base::FilePath& crash_envelope,
                           const std::string& report_id,
+                          bool wait_for_upload,
                           base::apple::ScopedMachReceiveRight receive_right,
                           HandlerStarter* handler_restarter,
                           bool restart) {
@@ -397,6 +403,9 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
     if (!report_id.empty()) {
       argv.push_back(FormatArgumentString("report-id", report_id));
     }
+    if (wait_for_upload) {
+      argv.push_back("--wait-for-upload");
+    }
 
     argv.push_back(FormatArgumentInt("handshake-fd", server_write_fd.get()));
 
@@ -438,7 +447,8 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
                           const std::vector<base::FilePath>& attachments,
                           const base::FilePath& crash_reporter,
                           const base::FilePath& crash_envelope,
-                          const std::string& report_id) {
+                          const std::string& report_id,
+                          bool wait_for_upload) {
     handler_ = handler;
     database_ = database;
     metrics_dir_ = metrics_dir;
@@ -450,6 +460,7 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
     crash_reporter_ = crash_reporter;
     crash_envelope_ = crash_envelope;
     report_id_ = report_id;
+    wait_for_upload_ = wait_for_upload;
 
     pthread_attr_t pthread_attr;
     errno = pthread_attr_init(&pthread_attr);
@@ -507,6 +518,7 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
   base::FilePath crash_reporter_;
   base::FilePath crash_envelope_;
   std::string report_id_;
+  bool wait_for_upload_;
   base::apple::ScopedMachReceiveRight notify_port_;
   uint64_t last_start_time_;
 };
@@ -535,8 +547,6 @@ bool CrashpadClient::StartHandler(
     const base::FilePath& crash_reporter,
     const base::FilePath& crash_envelope,
     const std::string& report_id) {
-  (void) wait_for_upload; // unused in mac (for now)
-
   // The “restartable” behavior can only be selected on OS X 10.10 and later. In
   // previous OS versions, if the initial client were to crash while attempting
   // to restart the handler, it would become an unkillable process.
@@ -552,6 +562,7 @@ bool CrashpadClient::StartHandler(
       crash_reporter,
       crash_envelope,
       report_id,
+      wait_for_upload,
       restartable && (__MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_10 ||
                       MacOSVersionNumber() >= 10'10'00)));
   if (!exception_port.is_valid()) {

--- a/handler/handler_main.cc
+++ b/handler/handler_main.cc
@@ -275,7 +275,7 @@ struct Options {
 #if defined(SCREENSHOT_SUPPORTED)
   base::FilePath screenshot;
 #endif  // SCREENSHOT_SUPPORTED
-#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
+#if BUILDFLAG(IS_APPLE) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
   bool wait_for_upload = false;
 #endif
   base::FilePath crash_reporter;
@@ -694,7 +694,7 @@ int HandlerMain(int argc,
 #if BUILDFLAG(IS_ANDROID)
     kOptionWriteMinidumpToLog,
 #endif  // BUILDFLAG(IS_ANDROID)
-#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
+#if BUILDFLAG(IS_APPLE) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
     kOptionWaitForUpload,
 #endif
     kOptionCrashReporter,
@@ -796,7 +796,7 @@ int HandlerMain(int argc,
 #if BUILDFLAG(IS_ANDROID)
     {"write-minidump-to-log", no_argument, nullptr, kOptionWriteMinidumpToLog},
 #endif  // BUILDFLAG(IS_ANDROID)
-#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
+#if BUILDFLAG(IS_APPLE) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
     {"wait-for-upload", no_argument, nullptr, kOptionWaitForUpload},
 #endif
     {"crash-reporter", required_argument, nullptr, kOptionCrashReporter},
@@ -995,7 +995,7 @@ int HandlerMain(int argc,
         break;
       }
 #endif  // BUILDFLAG(IS_ANDROID)
-#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
+#if BUILDFLAG(IS_APPLE) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
       case kOptionWaitForUpload : {
         options.wait_for_upload = true;
         break;
@@ -1213,7 +1213,7 @@ int HandlerMain(int argc,
       false,
 #endif  // BUILDFLAG(IS_LINUX)
       user_stream_sources
-#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
+#if BUILDFLAG(IS_APPLE) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN)
       ,options.wait_for_upload
 #endif
       ,&options.crash_reporter

--- a/handler/mac/crash_report_exception_handler.cc
+++ b/handler/mac/crash_report_exception_handler.cc
@@ -50,6 +50,7 @@ CrashReportExceptionHandler::CrashReportExceptionHandler(
     const std::map<std::string, std::string>* process_annotations,
     const std::vector<base::FilePath>* attachments,
     const UserStreamDataSources* user_stream_data_sources,
+    bool wait_for_upload,
     const base::FilePath* crash_reporter,
     const base::FilePath* crash_envelope,
     const UUID* report_id)
@@ -58,6 +59,7 @@ CrashReportExceptionHandler::CrashReportExceptionHandler(
       process_annotations_(process_annotations),
       attachments_(attachments),
       user_stream_data_sources_(user_stream_data_sources),
+      wait_for_upload_(wait_for_upload),
       crash_reporter_(crash_reporter),
       crash_envelope_(crash_envelope),
       report_id_(report_id) {}
@@ -229,7 +231,11 @@ kern_return_t CrashReportExceptionHandler::CatchMachException(
     if (has_crash_reporter) {
       database_->DeleteReport(uuid);
     } else if (upload_thread_) {
-      upload_thread_->ReportPending(uuid);
+      if (wait_for_upload_) {
+        upload_thread_->ReportPendingSync(uuid);
+      } else {
+        upload_thread_->ReportPending(uuid);
+      }
     }
   }
 

--- a/handler/mac/crash_report_exception_handler.h
+++ b/handler/mac/crash_report_exception_handler.h
@@ -56,12 +56,15 @@ class CrashReportExceptionHandler final
   //!     crash reports. For each crash report that is written, the data sources
   //!     are called in turn. These data sources may contribute additional
   //!     minidump streams. `nullptr` if not required.
+  //! \param[in] wait_for_upload If `true`, upload crash reports synchronously
+  //!     before returning from the exception handler.
   CrashReportExceptionHandler(
       CrashReportDatabase* database,
       CrashReportUploadThread* upload_thread,
       const std::map<std::string, std::string>* process_annotations,
       const std::vector<base::FilePath>* attachments,
       const UserStreamDataSources* user_stream_data_sources,
+      bool wait_for_upload,
       const base::FilePath* crash_reporter,
       const base::FilePath* crash_envelope,
       const UUID* report_id);
@@ -102,6 +105,7 @@ class CrashReportExceptionHandler final
   const std::map<std::string, std::string>* process_annotations_;  // weak
   const std::vector<base::FilePath>* attachments_;  // weak
   const UserStreamDataSources* user_stream_data_sources_;  // weak
+  bool wait_for_upload_;
   const base::FilePath* crash_reporter_;  // weak
   const base::FilePath* crash_envelope_;  // weak
   const UUID* report_id_;  // weak


### PR DESCRIPTION
`sentry_options_set_crashpad_wait_for_upload` is very useful for testing large TUS uploads, but it was quietly ignored on Mac. Pass `--wait-for-upload` through the Mac handler startup path, and parse it in the handler.

When enabled, use `ReportPendingSync()` from the Mac exception handler so tests can wait for upload completion before the handler exits.

See also:
- #121
- #126
