### PR TITLE
ci: pin windows-2022 for VS 2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           - name: Windows (x64)
             platform: windows-latest
           - name: Windows ClangCL (x64)
-            platform: windows-latest
+            platform: windows-2022
             CMAKE_DEFINES: -G 'Visual Studio 17 2022' -A x64 -T ClangCL
           - name: Windows (arm64)
             platform: windows-latest


### PR DESCRIPTION
Same story as in:
- https://github.com/getsentry/sentry-native/pull/1703

```
CMAKE_DEFINES=-G 'Visual Studio 17 2022' -A x64 -T ClangCL
CMake Error at CMakeLists.txt:2 (project):
  Generator

    Visual Studio 17 2022

  could not find any instance of Visual Studio.



-- Configuring incomplete, errors occurred!
```
https://github.com/getsentry/crashpad/actions/runs/25488628566/job/74790609472?pr=153

I chose the most straightforward way to make the CI green again - switch back to how it was before the recent Windows runner changes. Alternatively, we could bump it to VS 2026, or even have both?