### PR TITLE
feat: add error log for oversized crash reports (HTTP 413)

### DIFF
--- a/util/net/http_transport.cc
+++ b/util/net/http_transport.cc
@@ -16,6 +16,8 @@
 
 #include <utility>
 
+#include "base/logging.h"
+#include "base/strings/stringprintf.h"
 #include "util/net/http_body.h"
 
 namespace crashpad {
@@ -29,6 +31,24 @@ HTTPTransport::HTTPTransport()
 }
 
 HTTPTransport::~HTTPTransport() {
+}
+
+// static
+bool HTTPTransport::HandleHTTPStatus(unsigned long status_code) {
+  if (status_code >= 200 && status_code <= 203) {
+    return true;
+  }
+
+  switch (status_code) {
+    case 413:
+      LOG(ERROR) << "Crash report was discarded due to size limits "
+                    "(HTTP 413 Content Too Large).";
+      break;
+    default:
+      LOG(ERROR) << base::StringPrintf("HTTP status %lu", status_code);
+      break;
+  }
+  return false;
 }
 
 void HTTPTransport::SetURL(const std::string& url) {

--- a/util/net/http_transport.h
+++ b/util/net/http_transport.h
@@ -103,6 +103,11 @@ class HTTPTransport {
  protected:
   HTTPTransport();
 
+  //! \brief Handles an HTTP response status.
+  //!
+  //! \return `true` for HTTP statuses considered successful.
+  static bool HandleHTTPStatus(unsigned long status_code);
+
   const std::string& url() const { return url_; }
   const std::string& http_proxy() const { return http_proxy_; }
   const std::string& method() const { return method_; }

--- a/util/net/http_transport_libcurl.cc
+++ b/util/net/http_transport_libcurl.cc
@@ -486,9 +486,7 @@ bool HTTPTransportLibcurl::ExecuteSynchronously(std::string* response_body) {
     return false;
   }
 
-  if (status != 200) {
-    LOG(ERROR) << base::StringPrintf(
-        "HTTP status %ld, response = \"%s\"", status, response_body->c_str());
+  if (!HandleHTTPStatus(static_cast<unsigned long>(status))) {
     return false;
   }
 

--- a/util/net/http_transport_libcurl.cc
+++ b/util/net/http_transport_libcurl.cc
@@ -487,6 +487,8 @@ bool HTTPTransportLibcurl::ExecuteSynchronously(std::string* response_body) {
   }
 
   if (!HandleHTTPStatus(static_cast<unsigned long>(status))) {
+    LOG(ERROR) << base::StringPrintf("HTTP response = \"%s\"",
+                                     response_body->c_str());
     return false;
   }
 

--- a/util/net/http_transport_mac.mm
+++ b/util/net/http_transport_mac.mm
@@ -22,7 +22,6 @@
 #include "base/strings/sys_string_conversions.h"
 #include "build/build_config.h"
 #include "package.h"
-#include "util/misc/implicit_cast.h"
 #include "util/misc/metrics.h"
 #include "util/net/http_body.h"
 #include "util/net/url.h"

--- a/util/net/http_transport_mac.mm
+++ b/util/net/http_transport_mac.mm
@@ -19,7 +19,6 @@
 
 #include "base/apple/bridging.h"
 #include "base/apple/foundation_util.h"
-#include "base/strings/stringprintf.h"
 #include "base/strings/sys_string_conversions.h"
 #include "build/build_config.h"
 #include "package.h"
@@ -252,10 +251,8 @@ bool HTTPTransportMac::ExecuteNormalRequest(NSMutableURLRequest* request,
       LOG(ERROR) << "no http_response";
       return false;
     }
-    NSInteger http_status = [http_response statusCode];
-    if (http_status < 200 || http_status > 203) {
-      LOG(ERROR) << base::StringPrintf("HTTP status %ld",
-                                       implicit_cast<long>(http_status));
+    NSInteger status_code = [http_response statusCode];
+    if (!HandleHTTPStatus(static_cast<unsigned long>(status_code))) {
       return false;
     }
 
@@ -332,10 +329,8 @@ bool HTTPTransportMac::ExecuteProxyRequest(NSMutableURLRequest* request,
               dispatch_semaphore_signal(semaphore);
               return;
             }
-            NSInteger http_status = [http_response statusCode];
-            if (http_status < 200 || http_status > 203) {
-              LOG(ERROR) << base::StringPrintf(
-                  "HTTP status %ld", implicit_cast<long>(http_status));
+            NSInteger status_code = [http_response statusCode];
+            if (!HandleHTTPStatus(static_cast<unsigned long>(status_code))) {
               sync_rv = false;
               dispatch_semaphore_signal(semaphore);
               return;

--- a/util/net/http_transport_socket.cc
+++ b/util/net/http_transport_socket.cc
@@ -45,6 +45,8 @@ namespace {
 
 constexpr const char kCRLFTerminator[] = "\r\n";
 
+class Stream;
+
 class HTTPTransportSocket final : public HTTPTransport {
  public:
   HTTPTransportSocket() = default;
@@ -55,6 +57,9 @@ class HTTPTransportSocket final : public HTTPTransport {
   ~HTTPTransportSocket() override = default;
 
   bool ExecuteSynchronously(std::string* response_body) override;
+
+ private:
+  bool ReadResponse(Stream* stream, std::string* response_body);
 };
 
 struct ScopedAddrinfoTraits {
@@ -463,7 +468,7 @@ bool StartsWith(const std::string& str, const char* with, size_t len) {
   return str.compare(0, len, with) == 0;
 }
 
-bool ReadResponseLine(Stream* stream) {
+bool ReadResponseLine(Stream* stream, unsigned int* status_code) {
   std::string response_line;
   if (!ReadLine(stream, &response_line)) {
     LOG(ERROR) << "ReadLine";
@@ -477,10 +482,11 @@ bool ReadResponseLine(Stream* stream) {
       response_line.at(strlen(kHttp10) + 3) != ' ') {
     return false;
   }
-  unsigned int http_status = 0;
-  return base::StringToUint(response_line.substr(strlen(kHttp10), 3),
-                            &http_status) &&
-         http_status >= 200 && http_status <= 203;
+  if (!base::StringToUint(response_line.substr(strlen(kHttp10), 3),
+                          status_code)) {
+    return false;
+  }
+  return true;
 }
 
 bool ReadResponseHeaders(Stream* stream, HTTPHeaders* headers) {
@@ -514,10 +520,13 @@ bool ReadContentChunked(Stream* stream, std::string* body) {
   return false;
 }
 
-bool ReadResponse(Stream* stream, std::string* response_body) {
+bool HTTPTransportSocket::ReadResponse(Stream* stream,
+                                       std::string* response_body) {
   response_body->clear();
 
-  if (!ReadResponseLine(stream)) {
+  unsigned int status_code = 0;
+  if (!ReadResponseLine(stream, &status_code) ||
+      !HandleHTTPStatus(status_code)) {
     return false;
   }
 

--- a/util/net/http_transport_win.cc
+++ b/util/net/http_transport_win.cc
@@ -407,8 +407,7 @@ bool HTTPTransportWin::ExecuteSynchronously(std::string* response_body) {
     return false;
   }
 
-  if (status_code < 200 || status_code > 203) {
-    LOG(ERROR) << base::StringPrintf("HTTP status %lu", status_code);
+  if (!HandleHTTPStatus(status_code)) {
     return false;
   }
 


### PR DESCRIPTION
Same as getsentry/sentry-native#1647 but for crashpad. The `/minidump` endpoint was fixed to respond with 413 in getsentry/relay#5838.

Closes: getsentry/sentry-native#1487