### PR TITLE
fix(win): resolve correct symbol names in client-side stack traces for multi-module apps

### DIFF
--- a/snapshot/win/process_reader_win.cc
+++ b/snapshot/win/process_reader_win.cc
@@ -486,8 +486,41 @@ void ProcessReaderWin::ReadThreadData(bool is_64_reading_32) {
 
 #ifdef CLIENT_STACKTRACES_ENABLED
   DWORD options = SymGetOptions();
-  SymSetOptions(options | SYMOPT_UNDNAME);
-  SymInitialize(process_, NULL, TRUE);
+  SymSetOptions(options | SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS
+      | SYMOPT_FAIL_CRITICAL_ERRORS | SYMOPT_NO_PROMPTS);
+
+  // Build a dbghelp search path from every loaded module's directory so it
+  // can find each module's PDB next to its DLL and resolve symbols
+  std::wstring sym_search_path;
+  std::vector<ProcessInfo::Module> sym_modules;
+  if (process_info_.Modules(&sym_modules)) {
+    std::vector<std::wstring> dirs;
+    for (const auto& module : sym_modules) {
+      const std::wstring& module_path = module.name;
+      size_t sep = module_path.find_last_of(L"\\/");
+      if (sep == std::wstring::npos || sep == 0)
+        continue;
+      std::wstring dir = module_path.substr(0, sep);
+      bool dup = false;
+      for (const auto& existing : dirs) {
+        if (existing.size() == dir.size()
+            && _wcsicmp(existing.c_str(), dir.c_str()) == 0) {
+          dup = true;
+          break;
+        }
+      }
+      if (dup)
+        continue;
+      dirs.push_back(dir);
+      if (!sym_search_path.empty())
+        sym_search_path.push_back(L';');
+      sym_search_path.append(dir);
+    }
+  }
+
+  SymInitializeW(process_,
+      sym_search_path.empty() ? nullptr : sym_search_path.c_str(),
+      TRUE);
 #endif
 
   for (unsigned long i = 0; i < process_information->NumberOfThreads; ++i) {


### PR DESCRIPTION
This PR fixes incorrect or irrelevant function names in client-side stack traces (`CRASHPAD_ENABLE_STACKTRACE`) on Windows for applications composed of many modules.

## Problem

When the snapshot walks a crashed thread's stack (`ProcessReaderWin::ReadThreadData → DoStackWalk`), it resolves frame addresses to function names via `dbghelp`, initialized with a NULL symbol search path. Without a search path, `dbghelp` cannot locate each module’s PDB and falls back to the module’s export table, mislabeling internal (non-exported) functions with the nearest exported symbol.

This issue is mostly invisible in monolithic applications but breaks down in multi-module setups where code is split across many DLLs in different directories. In those cases, `dbghelp` cannot locate most PDB files, so frames resolve to unrelated or misleading symbols even though the underlying stack addresses are correct (x64/ARM64 unwinding still works via module unwind metadata and does not require PDBs).

A concrete example is the Unreal Engine Editor, where functionality is distributed across many `UnrealEditor-*.dll` modules and plugins located in separate `Binaries/` directories. In these cases, crash reports showed misleading callstacks, while packaged monolithic game builds were unaffected.

## Proposed fix

Build a symbol search path from the directories of all loaded modules (`process_info_.Modules()`) and pass it to `dbghelp` via `SymInitializeW`, allowing it to locate PDBs alongside their corresponding DLLs (equivalent to `cdb -y <dirs>`).

- Build a deduplicated `;`-separated directory list (case-insensitive deduplication).
- Add `SYMOPT_FAIL_CRITICAL_ERRORS | SYMOPT_NO_PROMPTS` to prevent dbghelp from blocking on dialogs in unattended environments, while keeping `SYMOPT_DEFERRED_LOADS` so symbol loading remains lazy and efficient across many modules.

Scoped to `CLIENT_STACKTRACES_ENABLED` on Windows only. No behavior changes when the feature is disabled. Single-file change with no API or public interface modifications.

Related items

- https://github.com/getsentry/sentry-unreal/issues/1422
- https://github.com/getsentry/sentry-native/pull/1811