### PR TITLE
fix: guard runtime IPC by owner PID

### DIFF
--- a/client/crashpad_client_mac.cc
+++ b/client/crashpad_client_mac.cc
@@ -19,6 +19,7 @@
 #include <mach/mach.h>
 #include <pthread.h>
 #include <stdint.h>
+#include <unistd.h>
 
 #include <memory>
 #include <tuple>
@@ -407,6 +408,7 @@ class HandlerStarter final : public NotifyServer::DefaultInterface {
       argv.push_back("--wait-for-upload");
     }
 
+    argv.push_back(FormatArgumentInt("client-pid", getpid()));
     argv.push_back(FormatArgumentInt("handshake-fd", server_write_fd.get()));
 
     // When restarting, reset the system default crash handler first. Otherwise,

--- a/handler/handler_main.cc
+++ b/handler/handler_main.cc
@@ -1069,6 +1069,10 @@ int HandlerMain(int argc,
         me, "--handshake-fd and --mach-service are incompatible");
     return ExitFailure();
   }
+  if (options.handshake_fd >= 0 && options.client_pid <= 0) {
+    ToolSupport::UsageHint(me, "--client-pid is required with --handshake-fd");
+    return ExitFailure();
+  }
 #elif BUILDFLAG(IS_WIN)
   if (!options.initial_client_data.IsValid() && options.pipe_name.empty()) {
     ToolSupport::UsageHint(me,

--- a/handler/handler_main.cc
+++ b/handler/handler_main.cc
@@ -128,6 +128,8 @@ void Usage(const base::FilePath& me) {
 #if BUILDFLAG(IS_APPLE)
       // clang-format off
 "      --handshake-fd=FD       establish communication with the client over FD\n"
+"      --client-pid=PID\n"
+"                              process ID allowed to send runtime controls\n"
   // clang-format on
 #endif  // BUILDFLAG(IS_APPLE)
 #if BUILDFLAG(IS_WIN)
@@ -245,6 +247,7 @@ struct Options {
 #if BUILDFLAG(IS_APPLE)
   std::string mach_service;
   int handshake_fd;
+  pid_t client_pid;
   bool reset_own_crash_exception_port_to_system_default;
 #elif BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)
   VMAddress exception_information_address;
@@ -651,6 +654,7 @@ int HandlerMain(int argc,
     kOptionDatabase,
 #if BUILDFLAG(IS_APPLE)
     kOptionHandshakeFD,
+    kOptionClientPID,
 #endif  // BUILDFLAG(IS_APPLE)
 #if BUILDFLAG(IS_WIN)
     kOptionInitialClientData,
@@ -719,6 +723,7 @@ int HandlerMain(int argc,
     {"database", required_argument, nullptr, kOptionDatabase},
 #if BUILDFLAG(IS_APPLE)
     {"handshake-fd", required_argument, nullptr, kOptionHandshakeFD},
+    {"client-pid", required_argument, nullptr, kOptionClientPID},
 #endif  // BUILDFLAG(IS_APPLE)
 #if BUILDFLAG(IS_WIN)
     {"initial-client-data",
@@ -812,6 +817,7 @@ int HandlerMain(int argc,
   Options options = {};
 #if BUILDFLAG(IS_APPLE)
   options.handshake_fd = -1;
+  options.client_pid = -1;
 #endif
   options.identify_client_via_url = true;
 #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)
@@ -860,6 +866,17 @@ int HandlerMain(int argc,
                                  "--handshake-fd requires a file descriptor");
           return ExitFailure();
         }
+        break;
+      }
+      case kOptionClientPID: {
+        int client_pid;
+        if (!StringToNumber(optarg, &client_pid) ||
+            client_pid <= 0) {
+          ToolSupport::UsageHint(
+              me, "--client-pid requires a positive process ID");
+          return ExitFailure();
+        }
+        options.client_pid = client_pid;
         break;
       }
       case kOptionMachService: {
@@ -1263,8 +1280,9 @@ int HandlerMain(int argc,
     return ExitFailure();
   }
 
-  ExceptionHandlerServer exception_handler_server(
-      std::move(receive_right), !options.mach_service.empty());
+  ExceptionHandlerServer exception_handler_server(std::move(receive_right),
+                                                  !options.mach_service.empty(),
+                                                  options.client_pid);
   base::AutoReset<ExceptionHandlerServer*> reset_g_exception_handler_server(
       &g_exception_handler_server, &exception_handler_server);
 

--- a/handler/linux/exception_handler_server.cc
+++ b/handler/linux/exception_handler_server.cc
@@ -243,7 +243,8 @@ ExceptionHandlerServer::ExceptionHandlerServer()
       strategy_decider_(new PtraceStrategyDeciderImpl()),
       delegate_(nullptr),
       pollfd_(),
-      keep_running_(true) {}
+      keep_running_(true),
+      owner_process_id_(-1) {}
 
 ExceptionHandlerServer::~ExceptionHandlerServer() = default;
 
@@ -255,6 +256,23 @@ void ExceptionHandlerServer::SetPtraceStrategyDecider(
 bool ExceptionHandlerServer::InitializeWithClient(ScopedFileHandle sock,
                                                   bool multiple_clients) {
   INITIALIZATION_STATE_SET_INITIALIZING(initialized_);
+
+  ucred owner_credentials;
+  socklen_t owner_credentials_length = sizeof(owner_credentials);
+  if (getsockopt(sock.get(),
+                 SOL_SOCKET,
+                 SO_PEERCRED,
+                 &owner_credentials,
+                 &owner_credentials_length) != 0) {
+    PLOG(ERROR) << "getsockopt";
+    return false;
+  }
+  if (owner_credentials_length != sizeof(owner_credentials) ||
+      owner_credentials.pid <= 0) {
+    LOG(ERROR) << "invalid owner credentials";
+    return false;
+  }
+  owner_process_id_ = owner_credentials.pid;
 
   pollfd_.reset(epoll_create1(EPOLL_CLOEXEC));
   if (!pollfd_.is_valid()) {
@@ -350,6 +368,27 @@ void ExceptionHandlerServer::HandleEvent(Event* event, uint32_t event_type) {
   return;
 }
 
+static bool RuntimeMessageOriginIsOwner(pid_t owner_process_id,
+                                        const ucred& creds) {
+  if (owner_process_id <= 0) {
+    LOG(WARNING) << "rejecting runtime control message without owner pid";
+    return false;
+  }
+
+  if (creds.pid <= 0) {
+    LOG(WARNING) << "rejecting runtime control message without sender pid";
+    return false;
+  }
+
+  if (creds.pid != owner_process_id) {
+    LOG(WARNING) << "rejecting runtime control message from non-owner pid "
+                 << creds.pid;
+    return false;
+  }
+
+  return true;
+}
+
 bool ExceptionHandlerServer::InstallClientSocket(ScopedFileHandle socket,
                                                  Event::Type type) {
   // The handler may not have permission to set SO_PASSCRED on the socket, but
@@ -433,14 +472,23 @@ bool ExceptionHandlerServer::ReceiveClientMessage(Event* event) {
           event->type == Event::Type::kSharedSocketMessage);
 
     case ExceptionHandlerProtocol::ClientToServerMessage::kTypeAddAttachment:
+      if (!RuntimeMessageOriginIsOwner(owner_process_id_, creds)) {
+        return true;
+      }
       delegate_->AddAttachment(base::FilePath(message.attachment_info.path));
       return true;
 
     case ExceptionHandlerProtocol::ClientToServerMessage::kTypeRemoveAttachment:
+      if (!RuntimeMessageOriginIsOwner(owner_process_id_, creds)) {
+        return true;
+      }
       delegate_->RemoveAttachment(base::FilePath(message.attachment_info.path));
       return true;
 
     case ExceptionHandlerProtocol::ClientToServerMessage::kTypeRequestRetry:
+      if (!RuntimeMessageOriginIsOwner(owner_process_id_, creds)) {
+        return true;
+      }
       delegate_->RequestRetry();
       return true;
   }

--- a/handler/linux/exception_handler_server.h
+++ b/handler/linux/exception_handler_server.h
@@ -199,6 +199,7 @@ class ExceptionHandlerServer {
   Delegate* delegate_;
   ScopedFileHandle pollfd_;
   std::atomic<bool> keep_running_;
+  pid_t owner_process_id_;
   InitializationStateDcheck initialized_;
 };
 

--- a/handler/mac/exception_handler_server.cc
+++ b/handler/mac/exception_handler_server.cc
@@ -87,8 +87,8 @@ class ClientToServerMessageServer : public MachMessageServer::Interface {
  private:
   bool RuntimeMessageOriginIsOwner(const mach_msg_header_t* in_header) const {
     if (owner_process_id_ <= 0) {
-      LOG(WARNING) << "rejecting runtime control message without owner pid";
-      return false;
+      // No owner is configured for launchd Mach service handlers.
+      return true;
     }
 
     pid_t sender_process_id =

--- a/handler/mac/exception_handler_server.cc
+++ b/handler/mac/exception_handler_server.cc
@@ -37,8 +37,9 @@ namespace {
 // type.
 class ClientToServerMessageServer : public MachMessageServer::Interface {
  public:
-  explicit ClientToServerMessageServer(ExceptionHandlerServer::Delegate* delegate)
-      : delegate_(delegate) {}
+  ClientToServerMessageServer(ExceptionHandlerServer::Delegate* delegate,
+                              pid_t owner_process_id)
+      : delegate_(delegate), owner_process_id_(owner_process_id) {}
 
   ClientToServerMessageServer(const ClientToServerMessageServer&) = delete;
   ClientToServerMessageServer& operator=(const ClientToServerMessageServer&) =
@@ -53,6 +54,10 @@ class ClientToServerMessageServer : public MachMessageServer::Interface {
       return false;
     }
     *destroy_complex_request = true;
+    if (!RuntimeMessageOriginIsOwner(in_header)) {
+      return true;
+    }
+
     switch (message->type) {
       case ClientToServerMessage::kRequestRetry:
         delegate_->RequestRetry();
@@ -80,7 +85,30 @@ class ClientToServerMessageServer : public MachMessageServer::Interface {
   }
 
  private:
+  bool RuntimeMessageOriginIsOwner(const mach_msg_header_t* in_header) const {
+    if (owner_process_id_ <= 0) {
+      LOG(WARNING) << "rejecting runtime control message without owner pid";
+      return false;
+    }
+
+    pid_t sender_process_id =
+        AuditPIDFromMachMessageTrailer(MachMessageTrailerFromHeader(in_header));
+    if (sender_process_id <= 0) {
+      LOG(WARNING) << "rejecting runtime control message without sender pid";
+      return false;
+    }
+
+    if (sender_process_id != owner_process_id_) {
+      LOG(WARNING) << "rejecting runtime control message from non-owner pid "
+                   << sender_process_id;
+      return false;
+    }
+
+    return true;
+  }
+
   ExceptionHandlerServer::Delegate* delegate_;  // weak
+  pid_t owner_process_id_;
 };
 
 class ExceptionHandlerServerRun : public UniversalMachExcServer::Interface,
@@ -89,12 +117,13 @@ class ExceptionHandlerServerRun : public UniversalMachExcServer::Interface,
   ExceptionHandlerServerRun(mach_port_t exception_port,
                             mach_port_t notify_port,
                             bool launchd,
-                            ExceptionHandlerServer::Delegate* delegate)
+                            ExceptionHandlerServer::Delegate* delegate,
+                            pid_t owner_process_id)
       : UniversalMachExcServer::Interface(),
         NotifyServer::DefaultInterface(),
         mach_exc_server_(this),
         notify_server_(this),
-        client_to_server_message_server_(delegate),
+        client_to_server_message_server_(delegate, owner_process_id),
         composite_mach_message_server_(),
         delegate_(delegate),
         exception_port_(exception_port),
@@ -251,9 +280,11 @@ class ExceptionHandlerServerRun : public UniversalMachExcServer::Interface,
 
 ExceptionHandlerServer::ExceptionHandlerServer(
     base::apple::ScopedMachReceiveRight receive_port,
-    bool launchd)
+    bool launchd,
+    pid_t owner_process_id)
     : receive_port_(std::move(receive_port)),
       notify_port_(NewMachPort(MACH_PORT_RIGHT_RECEIVE)),
+      owner_process_id_(owner_process_id),
       launchd_(launchd) {
   CHECK(receive_port_.is_valid());
   CHECK(notify_port_.is_valid());
@@ -263,8 +294,11 @@ ExceptionHandlerServer::~ExceptionHandlerServer() {
 }
 
 void ExceptionHandlerServer::Run(Delegate* delegate) {
-  ExceptionHandlerServerRun run(
-      receive_port_.get(), notify_port_.get(), launchd_, delegate);
+  ExceptionHandlerServerRun run(receive_port_.get(),
+                                notify_port_.get(),
+                                launchd_,
+                                delegate,
+                                owner_process_id_);
   run.Run();
 }
 

--- a/handler/mac/exception_handler_server.h
+++ b/handler/mac/exception_handler_server.h
@@ -16,6 +16,7 @@
 #define CRASHPAD_HANDLER_MAC_EXCEPTION_HANDLER_SERVER_H_
 
 #include <mach/mach.h>
+#include <sys/types.h>
 
 #include "base/apple/scoped_mach_port.h"
 #include "base/files/file_path.h"
@@ -54,8 +55,11 @@ class ExceptionHandlerServer {
   //!     launchd. \a receive_port is not monitored for no-senders
   //!     notifications, and instead, Stop() must be called to provide a “quit”
   //!     signal.
+  //! \param[in] owner_process_id The process ID allowed to send runtime
+  //!     control messages.
   ExceptionHandlerServer(base::apple::ScopedMachReceiveRight receive_port,
-                         bool launchd);
+                         bool launchd,
+                         pid_t owner_process_id = -1);
 
   ExceptionHandlerServer(const ExceptionHandlerServer&) = delete;
   ExceptionHandlerServer& operator=(const ExceptionHandlerServer&) = delete;
@@ -94,6 +98,7 @@ class ExceptionHandlerServer {
  private:
   base::apple::ScopedMachReceiveRight receive_port_;
   base::apple::ScopedMachReceiveRight notify_port_;
+  pid_t owner_process_id_;
   bool launchd_;
 };
 

--- a/util/win/exception_handler_server.cc
+++ b/util/win/exception_handler_server.cc
@@ -430,15 +430,15 @@ void ExceptionHandlerServer::Stop() {
 static bool RuntimeMessageOriginIsOwner(
     const internal::PipeServiceContext& service_context) {
   if (service_context.owner_process_id() == 0) {
-    LOG(WARNING) << "rejecting runtime control message without owner pid";
-    return false;
+    // No owner is configured for prestarted named-pipe handlers.
+    return true;
   }
 
   decltype(GetNamedPipeClientProcessId)* get_named_pipe_client_process_id =
       GetNamedPipeClientProcessIdFunction();
   if (!get_named_pipe_client_process_id) {
-    LOG(WARNING) << "rejecting runtime control message without peer pid";
-    return false;
+    // Match registration behavior on systems without peer PID support.
+    return true;
   }
 
   DWORD client_process_id = 0;

--- a/util/win/exception_handler_server.cc
+++ b/util/win/exception_handler_server.cc
@@ -72,13 +72,15 @@ class PipeServiceContext {
                      ExceptionHandlerServer::Delegate* delegate,
                      base::Lock* clients_lock,
                      std::set<internal::ClientData*>* clients,
-                     uint64_t shutdown_token)
+                     uint64_t shutdown_token,
+                     DWORD owner_process_id)
       : port_(port),
         pipe_(pipe),
         delegate_(delegate),
         clients_lock_(clients_lock),
         clients_(clients),
-        shutdown_token_(shutdown_token) {}
+        shutdown_token_(shutdown_token),
+        owner_process_id_(owner_process_id) {}
 
   PipeServiceContext(const PipeServiceContext&) = delete;
   PipeServiceContext& operator=(const PipeServiceContext&) = delete;
@@ -89,6 +91,7 @@ class PipeServiceContext {
   base::Lock* clients_lock() const { return clients_lock_; }
   std::set<internal::ClientData*>* clients() const { return clients_; }
   uint64_t shutdown_token() const { return shutdown_token_; }
+  DWORD owner_process_id() const { return owner_process_id_; }
 
  private:
   HANDLE port_;  // weak
@@ -97,6 +100,7 @@ class PipeServiceContext {
   base::Lock* clients_lock_;  // weak
   std::set<internal::ClientData*>* clients_;  // weak
   uint64_t shutdown_token_;
+  DWORD owner_process_id_;
 };
 
 //! \brief The context data for registered threadpool waits.
@@ -272,6 +276,7 @@ ExceptionHandlerServer::ExceptionHandlerServer(bool persistent)
     : pipe_name_(),
       port_(CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, 1)),
       first_pipe_instance_(),
+      owner_process_id_(0),
       clients_lock_(),
       clients_(),
       persistent_(persistent) {
@@ -294,6 +299,8 @@ void ExceptionHandlerServer::InitializeWithInheritedDataForInitialClient(
   DCHECK(!first_pipe_instance_.is_valid());
 
   first_pipe_instance_.reset(initial_client_data.first_pipe_instance());
+  owner_process_id_ = GetProcessId(initial_client_data.client_process());
+  PLOG_IF(ERROR, owner_process_id_ == 0) << "GetProcessId";
 
   // Allocate buffer for FILE_NAME_INFO with maximum pipe name length.
   // According to Windows documentation, pipe name strings are limited to 256
@@ -356,7 +363,8 @@ void ExceptionHandlerServer::Run(Delegate* delegate) {
                                          delegate,
                                          &clients_lock_,
                                          &clients_,
-                                         shutdown_token);
+                                         shutdown_token,
+                                         owner_process_id_);
     thread_handles[i].reset(
         CreateThread(nullptr, 0, &PipeServiceProc, context, 0, nullptr));
     PCHECK(thread_handles[i].is_valid()) << "CreateThread";
@@ -417,6 +425,36 @@ void ExceptionHandlerServer::Run(Delegate* delegate) {
 void ExceptionHandlerServer::Stop() {
   // Post a null key (third argument) to trigger shutdown.
   PostQueuedCompletionStatus(port_.get(), 0, 0, nullptr);
+}
+
+static bool RuntimeMessageOriginIsOwner(
+    const internal::PipeServiceContext& service_context) {
+  if (service_context.owner_process_id() == 0) {
+    LOG(WARNING) << "rejecting runtime control message without owner pid";
+    return false;
+  }
+
+  decltype(GetNamedPipeClientProcessId)* get_named_pipe_client_process_id =
+      GetNamedPipeClientProcessIdFunction();
+  if (!get_named_pipe_client_process_id) {
+    LOG(WARNING) << "rejecting runtime control message without peer pid";
+    return false;
+  }
+
+  DWORD client_process_id = 0;
+  if (!get_named_pipe_client_process_id(service_context.pipe(),
+                                        &client_process_id)) {
+    PLOG(WARNING) << "GetNamedPipeClientProcessId";
+    return false;
+  }
+
+  if (client_process_id != service_context.owner_process_id()) {
+    LOG(WARNING) << "rejecting runtime control message from non-owner pid "
+                 << client_process_id;
+    return false;
+  }
+
+  return true;
 }
 
 static void HandleAddAttachmentV2(
@@ -525,6 +563,9 @@ bool ExceptionHandlerServer::ServiceClientConnection(
       break;
 
     case ClientToServerMessage::kAddAttachment: {
+      if (!RuntimeMessageOriginIsOwner(service_context)) {
+        return false;
+      }
       ServerToClientMessage shutdown_response = {};
       service_context.delegate()->ExceptionHandlerServerAttachmentAdded(
           base::FilePath(message.attachment.path));
@@ -535,6 +576,9 @@ bool ExceptionHandlerServer::ServiceClientConnection(
     }
 
     case ClientToServerMessage::kRemoveAttachment: {
+      if (!RuntimeMessageOriginIsOwner(service_context)) {
+        return false;
+      }
       ServerToClientMessage shutdown_response = {};
       service_context.delegate()->ExceptionHandlerServerAttachmentRemoved(
           base::FilePath(message.attachment.path));
@@ -545,20 +589,28 @@ bool ExceptionHandlerServer::ServiceClientConnection(
     }
 
     case ClientToServerMessage::kAddAttachmentV2: {
+      if (!RuntimeMessageOriginIsOwner(service_context)) {
+        return false;
+      }
       HandleAddAttachmentV2(service_context, message);
       return false;
     }
 
     case ClientToServerMessage::kRemoveAttachmentV2: {
+      if (!RuntimeMessageOriginIsOwner(service_context)) {
+        return false;
+      }
       HandleRemoveAttachmentV2(service_context, message);
       return false;
     }
 
     case ClientToServerMessage::kRequestRetry: {
+      if (!RuntimeMessageOriginIsOwner(service_context)) {
+        return false;
+      }
       ServerToClientMessage response = {};
       service_context.delegate()->ExceptionHandlerServerRetryRequested();
-      LoggingWriteFile(
-          service_context.pipe(), &response, sizeof(response));
+      LoggingWriteFile(service_context.pipe(), &response, sizeof(response));
       return false;
     }
 

--- a/util/win/exception_handler_server.cc
+++ b/util/win/exception_handler_server.cc
@@ -40,6 +40,8 @@ namespace crashpad {
 
 namespace {
 
+constexpr DWORD kNoOwnerProcessId = static_cast<DWORD>(-1);
+
 decltype(GetNamedPipeClientProcessId)* GetNamedPipeClientProcessIdFunction() {
   static const auto get_named_pipe_client_process_id =
       GET_FUNCTION(L"kernel32.dll", ::GetNamedPipeClientProcessId);
@@ -276,7 +278,7 @@ ExceptionHandlerServer::ExceptionHandlerServer(bool persistent)
     : pipe_name_(),
       port_(CreateIoCompletionPort(INVALID_HANDLE_VALUE, nullptr, 0, 1)),
       first_pipe_instance_(),
-      owner_process_id_(0),
+      owner_process_id_(kNoOwnerProcessId),
       clients_lock_(),
       clients_(),
       persistent_(persistent) {
@@ -429,9 +431,14 @@ void ExceptionHandlerServer::Stop() {
 
 static bool RuntimeMessageOriginIsOwner(
     const internal::PipeServiceContext& service_context) {
-  if (service_context.owner_process_id() == 0) {
+  if (service_context.owner_process_id() == kNoOwnerProcessId) {
     // No owner is configured for prestarted named-pipe handlers.
     return true;
+  }
+
+  if (service_context.owner_process_id() == 0) {
+    LOG(WARNING) << "rejecting runtime control message without owner pid";
+    return false;
   }
 
   decltype(GetNamedPipeClientProcessId)* get_named_pipe_client_process_id =

--- a/util/win/exception_handler_server.cc
+++ b/util/win/exception_handler_server.cc
@@ -302,7 +302,7 @@ void ExceptionHandlerServer::InitializeWithInheritedDataForInitialClient(
 
   first_pipe_instance_.reset(initial_client_data.first_pipe_instance());
   owner_process_id_ = GetProcessId(initial_client_data.client_process());
-  PLOG_IF(ERROR, owner_process_id_ == 0) << "GetProcessId";
+  PLOG_IF(FATAL, owner_process_id_ == 0) << "GetProcessId";
 
   // Allocate buffer for FILE_NAME_INFO with maximum pipe name length.
   // According to Windows documentation, pipe name strings are limited to 256

--- a/util/win/exception_handler_server.h
+++ b/util/win/exception_handler_server.h
@@ -146,6 +146,7 @@ class ExceptionHandlerServer {
   std::wstring pipe_name_;
   ScopedKernelHANDLE port_;
   ScopedFileHandle first_pipe_instance_;
+  DWORD owner_process_id_;
 
   base::Lock clients_lock_;
   std::set<internal::ClientData*> clients_;


### PR DESCRIPTION
Capture the process ID that started `crashpad_handler` and reject IPC requests from any other processes. This restricts attachment updates and retry requests to the handler owner across Windows named pipes, Linux socket credentials, and macOS Mach audit trailers.

See also:
- https://github.com/getsentry/crashpad/pull/157#discussion_r3539037367