### PR TITLE
fix(posix): report spawn failures safely from the parent process

### DIFF
--- a/util/posix/spawn_subprocess.cc
+++ b/util/posix/spawn_subprocess.cc
@@ -190,7 +190,8 @@ bool SpawnSubprocess(const std::vector<std::string>& argv,
 
     auto execve_fp = use_path ? execvpe : execve;
     execve_fp(argv_for_spawn[0], argv_for_spawn, envp_for_spawn);
-    _exit(errno);
+    PLOG(FATAL) << (use_path ? "execvpe" : "execve") << " "
+                << argv_for_spawn[0];
 #else
 #if BUILDFLAG(IS_APPLE)
     PosixSpawnAttr attr;

--- a/util/posix/spawn_subprocess.cc
+++ b/util/posix/spawn_subprocess.cc
@@ -190,8 +190,7 @@ bool SpawnSubprocess(const std::vector<std::string>& argv,
 
     auto execve_fp = use_path ? execvpe : execve;
     execve_fp(argv_for_spawn[0], argv_for_spawn, envp_for_spawn);
-    PLOG(FATAL) << (use_path ? "execvpe" : "execve") << " "
-                << argv_for_spawn[0];
+    _exit(errno);
 #else
 #if BUILDFLAG(IS_APPLE)
     PosixSpawnAttr attr;
@@ -219,8 +218,7 @@ bool SpawnSubprocess(const std::vector<std::string>& argv,
                                 attr_p,
                                 argv_for_spawn,
                                 envp_for_spawn)) != 0) {
-      PLOG(FATAL) << (use_path ? "posix_spawnp" : "posix_spawn") << " "
-                  << argv_for_spawn[0];
+      _exit(errno);
     }
 
     // _exit() instead of exit(), because fork() was called.
@@ -253,8 +251,9 @@ bool SpawnSubprocess(const std::vector<std::string>& argv,
     LOG(WARNING) << base::StringPrintf(
         "intermediate process: unknown termination 0x%x", status);
   } else if (WEXITSTATUS(status) != EXIT_SUCCESS) {
-    LOG(WARNING) << "intermediate process exited with code "
-                 << WEXITSTATUS(status);
+    const int exit_status = WEXITSTATUS(status);
+      LOG(ERROR) << base::StringPrintf("failed to spawn %s: %s (%d)",
+        argv_c[0], strerror(exit_status), exit_status);
   }
 
   return true;


### PR DESCRIPTION
Move `spawn` and `exec` failure logging out of the forked intermediate process. Exit with `errno` from the child and construct the failure message after `waitpid` returns in the parent. This keeps diagnostics such as "permission denied" handler startup failures visible without running the logging machinery in the intermediate forked child, which would be [unsafe](https://github.com/getsentry/sentry-native/pull/1859#discussion_r3569205204) to forward to Sentry's logger.

Required for:
- getsentry/sentry-native#1859