### PR TITLE
build: require C++17 for `crashpad_client` consumers

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -75,7 +75,7 @@ target_link_libraries(crashpad_client
         crashpad_util
         mini_chromium
 )
-target_compile_features(crashpad_client PUBLIC cxx_std_14)
+target_compile_features(crashpad_client PUBLIC cxx_std_17)
 
 set_property(TARGET crashpad_client PROPERTY EXPORT_NAME client)
 add_library(crashpad::client ALIAS crashpad_client)


### PR DESCRIPTION
Brought up at:
- https://github.com/getsentry/crashpad/pull/1#discussion_r3558666219

The Sentry-maintained CMake metadata for `crashpad_client` still advertised `cxx_std_14`, but the headers it installs and exposes use C++17 library types such as `std::optional` and `std::string_view`. That lets CMake consumers compile against those headers with an insufficient language standard.

Update the exported usage requirement to `cxx_std_17` so the CMake build stays in sync with the upstream Crashpad source requirements. This does not raise sentry-native's effective Crashpad requirement:
- Crashpad already sets `CMAKE_CXX_STANDARD` to `17` with `CMAKE_CXX_STANDARD_REQUIRED` enabled, and

  - https://github.com/getsentry/crashpad/blob/36801259f1a75a2cf400ca7788bd20b371c0c8f4/CMakeLists.txt#L89-L90

- sentry-native documents the Crashpad backend as requiring a C++17-compatible compiler:
   > Building the Breakpad and Crashpad backends requires a `C++17` compatible compiler.

   https://github.com/getsentry/sentry-native/blob/034e49d521574ad4f3a7d018ef733e5b8a3bbcb1/README.md?plain=1#L101