### PR TITLE
fix(ios): add missing sources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
           [ "${{ matrix.CC }}" ] && export CC="${{ matrix.CC }}"
           [ "${{ matrix.CXX }}" ] && export CXX="${{ matrix.CXX }}"
           echo "CMAKE_DEFINES=${CMAKE_DEFINES}"
-          eval "cmake -B cmake-build -D CRASHPAD_BUILD_TOOLS=On $CMAKE_DEFINES"
+          eval "cmake -B cmake-build -D CRASHPAD_BUILD_TOOLS=On -D CRASHPAD_BUILD_LINK_TESTS=ON $CMAKE_DEFINES"
           cmake --build cmake-build --parallel
 
       - name: Build crashpad with client-side stack traces
@@ -138,7 +138,7 @@ jobs:
           [ "${{ matrix.CC }}" ] && export CC="${{ matrix.CC }}"
           [ "${{ matrix.CXX }}" ] && export CXX="${{ matrix.CXX }}"
           echo "CMAKE_DEFINES=${CMAKE_DEFINES}"
-          eval "cmake -B cmake-build-stacks -D CRASHPAD_ENABLE_STACKTRACE=ON $CMAKE_DEFINES"
+          eval "cmake -B cmake-build-stacks -D CRASHPAD_ENABLE_STACKTRACE=ON -D CRASHPAD_BUILD_LINK_TESTS=OFF $CMAKE_DEFINES"
           cmake --build cmake-build-stacks --parallel
 
   build-ios:
@@ -149,5 +149,9 @@ jobs:
         with:
           submodules: "recursive"
       - run: |
-          cmake -B crashpad-xcode -GXcode -DCMAKE_SYSTEM_NAME=iOS
-          xcodebuild build -project crashpad-xcode/crashpad.xcodeproj
+          cmake -B crashpad-xcode -GXcode -DCMAKE_SYSTEM_NAME=iOS -DCRASHPAD_BUILD_LINK_TESTS=ON
+          xcodebuild build \
+            -project crashpad-xcode/crashpad.xcodeproj \
+            -target crashpad_client_link_test \
+            -sdk iphonesimulator \
+            CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,5 +153,4 @@ jobs:
           xcodebuild build \
             -project crashpad-xcode/crashpad.xcodeproj \
             -target crashpad_client_link_test \
-            -sdk iphonesimulator \
             CODE_SIGNING_ALLOWED=NO

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 option(CRASHPAD_ENABLE_INSTALL "Enable crashpad installation" "${CRASHPAD_MAIN_PROJECT}")
 option(CRASHPAD_ENABLE_INSTALL_DEV "Enable crashpad development installation" "${CRASHPAD_MAIN_PROJECT}")
 option(CRASHPAD_ENABLE_STACKTRACE "Enable client-side stack trace recording" OFF)
+option(CRASHPAD_BUILD_LINK_TESTS "Build crashpad link tests")
 
 if(MSVC)
     set(CRASHPAD_ZLIB_SYSTEM_DEFAULT OFF)
@@ -179,6 +180,9 @@ add_subdirectory(third_party/mpack)
 
 add_subdirectory(tools)
 add_subdirectory(handler)
+if(CRASHPAD_BUILD_LINK_TESTS)
+    add_subdirectory(test/link)
+endif()
 
 if(CRASHPAD_ENABLE_STACKTRACE AND APPLE AND NOT IOS)
     set(LIBUNWIND_ENABLE_SHARED OFF)

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -109,6 +109,7 @@ endif()
 if(IOS)
     target_link_libraries(crashpad_client
         PUBLIC
+            crashpad_handler_lib
             crashpad_minidump
             crashpad_snapshot
     )

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -30,6 +30,10 @@ endif()
 
 if(IOS)
     target_sources(crashpad_client PRIVATE
+        crash_handler_base_ios.cc
+        crash_handler_base_ios.h
+        crash_handler_ios.cc
+        crash_handler_ios.h
         crash_report_database_mac.mm
         crashpad_client_ios.cc
         ios_handler/exception_processor.h
@@ -41,6 +45,7 @@ if(IOS)
         ios_handler/prune_intermediate_dumps_and_crash_reports_thread.cc
         ios_handler/prune_intermediate_dumps_and_crash_reports_thread.h
         simulate_crash_ios.h
+        upload_behavior_ios.h
     )
 endif()
 

--- a/test/link/CMakeLists.txt
+++ b/test/link/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(crashpad_client_link_test
+    client_link_test.cc
+)
+
+target_link_libraries(crashpad_client_link_test PRIVATE
+    crashpad_client
+)
+
+if(IOS)
+    set_target_properties(crashpad_client_link_test PROPERTIES
+        MACOSX_BUNDLE TRUE
+        XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED NO
+        XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED NO
+        XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER org.crashpad.client-link-test
+    )
+endif()

--- a/test/link/CMakeLists.txt
+++ b/test/link/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(crashpad_client_link_test
     client_link_test.cc
 )
+set_property(TARGET crashpad_client_link_test PROPERTY WIN32_EXECUTABLE OFF)
 
 target_link_libraries(crashpad_client_link_test PRIVATE
     crashpad_client

--- a/test/link/client_link_test.cc
+++ b/test/link/client_link_test.cc
@@ -21,7 +21,11 @@
 #include "base/files/file_path.h"
 #include "build/build_config.h"
 
+#if BUILDFLAG(IS_WIN)
+int wmain(int, wchar_t*[]) {
+#else
 int main() {
+#endif
 #if BUILDFLAG(IS_IOS)
   crashpad::CrashpadClient::StartCrashpadInProcessHandler(
       base::FilePath(),

--- a/test/link/client_link_test.cc
+++ b/test/link/client_link_test.cc
@@ -1,0 +1,43 @@
+// Copyright 2026 The Crashpad Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "client/crashpad_client.h"
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "base/files/file_path.h"
+#include "build/build_config.h"
+
+int main() {
+#if BUILDFLAG(IS_IOS)
+  crashpad::CrashpadClient::StartCrashpadInProcessHandler(
+      base::FilePath(),
+      std::string(),
+      std::map<std::string, std::string>(),
+      crashpad::CrashpadClient::ProcessPendingReportsObservationCallback());
+#else
+  crashpad::CrashpadClient client;
+  client.StartHandler(base::FilePath(),
+                      base::FilePath(),
+                      base::FilePath(),
+                      std::string(),
+                      std::string(),
+                      std::map<std::string, std::string>(),
+                      std::vector<std::string>(),
+                      false,
+                      false);
+#endif
+}

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -167,6 +167,8 @@ if(APPLE)
         mach/mach_message_server.h
         mach/symbolic_constants_mach.cc
         mach/symbolic_constants_mach.h
+        mac/sysctl.cc
+        mac/sysctl.h
         misc/capture_context_mac.S
         misc/clock_mac.cc
         misc/paths_mac.cc
@@ -182,8 +184,6 @@ if(APPLE)
             mac/mac_util.h
             mac/service_management.cc
             mac/service_management.h
-            mac/sysctl.cc
-            mac/sysctl.h
             mach/bootstrap.cc
             mach/bootstrap.h
             mach/child_port_handshake.cc


### PR DESCRIPTION
https://github.com/getsentry/crashpad/pull/1#discussion_r3558666214

> ### Missing iOS crash handler sources
> 
> **High Severity**
> 
> The iOS CMake sources omit `crash_handler_base_ios`, `crash_handler_ios` / `crash_handler_tvos`, and `upload_behavior_ios`, which `BUILD.gn` adds and which `crashpad_client_ios.cc` includes. An iOS CMake build, including the new `build-ios` workflow job, cannot link the client.
> 
> <details>
> <summary>Additional Locations (2)</summary>
> 
> - [`client/BUILD.gn#L32-L60`](https://github.com/getsentry/crashpad/blob/2ab129bdc012bdc7182fea74081343889cbd8061/client/BUILD.gn#L32-L60)
> - [`.github/workflows/build.yml#L143-L153`](https://github.com/getsentry/crashpad/blob/2ab129bdc012bdc7182fea74081343889cbd8061/.github/workflows/build.yml#L143-L153)
> </details>