### PR TITLE
fix: Synchronize pending crash report processing

### DIFF
--- a/handler/crash_report_upload_thread.cc
+++ b/handler/crash_report_upload_thread.cc
@@ -104,6 +104,7 @@ CrashReportUploadThread::CrashReportUploadThread(
                                             : WorkerThread::kIndefiniteWait,
               this),
       known_pending_report_uuids_(),
+      process_pending_reports_lock_(),
       database_(database) {
   DCHECK(!url_.empty());
 }
@@ -137,6 +138,8 @@ void CrashReportUploadThread::Stop() {
 }
 
 void CrashReportUploadThread::ProcessPendingReports() {
+  base::AutoLock lock(process_pending_reports_lock_);
+
 #if BUILDFLAG(IS_IOS)
   internal::ScopedBackgroundTask scoper("CrashReportUploadThread");
 #endif  // BUILDFLAG(IS_IOS)

--- a/handler/crash_report_upload_thread.h
+++ b/handler/crash_report_upload_thread.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <unordered_map>
 
+#include "base/synchronization/lock.h"
 #include "build/build_config.h"
 #include "client/crash_report_database.h"
 #include "util/misc/uuid.h"
@@ -247,7 +248,8 @@ class CrashReportUploadThread : public WorkerThread::Delegate,
   const std::string http_proxy_;
   WorkerThread thread_;
   ThreadSafeVector<UUID> known_pending_report_uuids_;
-  // This is not thread-safe, and only used by the worker thread.
+  base::Lock process_pending_reports_lock_;
+  // Guarded by process_pending_reports_lock_.
   std::map<UUID, time_t> retry_uuid_time_map_;
   CrashReportDatabase* database_;  // weak
 };


### PR DESCRIPTION
Required for:
- https://github.com/getsentry/sentry-native/pull/1885

Fixes the flakiness of Crashpad integration tests that have been failing often, especially on Windows.

`ReportPendingSync()` adds a report UUID to the pending queue and invokes `DoWork()` directly. The upload worker can call `ProcessPendingReports()` at the same time and consume that UUID before the synchronous caller does. The synchronous call can then return while the worker is still uploading and marking the report completed.

On Windows, this makes `crashpad-wait-for-upload` unreliable. A process started immediately afterward for session recovery may query Crashpad before the crash report is completed, causing the crash session to be missed and the integration test to fail intermittently.

Serialize `ProcessPendingReports()` so synchronous requests wait for any active worker pass and do not return before the queued report has been fully processed.