### PR TITLE
fix(windows): flush attachment IPC responses

### DIFF
--- a/util/win/exception_handler_server.cc
+++ b/util/win/exception_handler_server.cc
@@ -493,7 +493,10 @@ static void HandleAddAttachmentV2(
   ServerToClientMessage response = {};
   service_context.delegate()->ExceptionHandlerServerAttachmentAdded(
       base::FilePath(std::wstring(path_buffer.data())));
-  LoggingWriteFile(service_context.pipe(), &response, sizeof(response));
+  if (LoggingWriteFile(service_context.pipe(), &response, sizeof(response)) &&
+      !FlushFileBuffers(service_context.pipe())) {
+    PLOG(ERROR) << "FlushFileBuffers";
+  }
 }
 
 static void HandleRemoveAttachmentV2(
@@ -525,7 +528,10 @@ static void HandleRemoveAttachmentV2(
   ServerToClientMessage response = {};
   service_context.delegate()->ExceptionHandlerServerAttachmentRemoved(
       base::FilePath(std::wstring(path_buffer.data())));
-  LoggingWriteFile(service_context.pipe(), &response, sizeof(response));
+  if (LoggingWriteFile(service_context.pipe(), &response, sizeof(response)) &&
+      !FlushFileBuffers(service_context.pipe())) {
+    PLOG(ERROR) << "FlushFileBuffers";
+  }
 }
 
 // This function must be called with service_context.pipe() already connected to


### PR DESCRIPTION
Fixes a runtime attachment IPC race on Windows: the handler wrote a response and then sometimes disconnected the named pipe too soon before the client had read it.

Under stress, this aborted the crashing process in Crashpad with `ERROR_PIPE_NOT_CONNECTED` or `!IsSocketHandle(file)`, preventing normal crash handling and causing flaky failures in `sentry-native/tests/test_integration_crashpad.py`.