### PR TITLE
Stop capturing the static TLS block with every thread's stack

### DIFF
--- a/snapshot/linux/process_reader_linux.cc
+++ b/snapshot/linux/process_reader_linux.cc
@@ -204,6 +204,11 @@ void ProcessReaderLinux::Thread::InitializeStackFromSP(
   if (tid != reader->ProcessID() && tls_address > stack_region_address &&
       tls_address < stack_end) {
     stack_region_size = tls_address - stack_region_address;
+
+    // Truncating the length drops the static TLS block, which sits at the
+    // stack base end of the region, rather than any frame.
+    constexpr LinuxVMSize kMaxCapturedStackSize = 64 * 1024;
+    stack_region_size = std::min(stack_region_size, kMaxCapturedStackSize);
   }
 }
 


### PR DESCRIPTION
### Problem

`ProcessReaderLinux::Thread::InitializeStackFromSP` bounds a thread's stack capture with the thread pointer, which is a big improvement on capturing the whole mapping. On glibc, though, the static TLS block sits immediately *below* the thread pointer, at the high-address end of that same mapping — so every thread is captured as `live stack + the entire static TLS block`.

The block scales with the number of loaded DSOs, not with anything about the thread.

I byte-parsed a 144.9 MB minidump from a production application:

| region | bytes | share |
|---|---|---|
| header, directory, module list, thread list, contexts | 1.09 MB | 0.8% |
| **thread stacks (818 threads)** | **143.8 MB** | **99.2%** |

Per thread that is ~175 KB, of which around **700 bytes** was live stack — the rest zeroes. The contributors are ordinary libraries: `libglog`'s `thread_local LogMessageData` is 30,448 B on its own (it holds a 30,001-byte message buffer), plus ~4 KB each from `libcudart` and eight `libnpp*`. The intra-application spread was ±3%, which is the signature of a fixed per-thread constant rather than of stack usage.

### Fix

Cap the captured length for non-main threads. The region starts at the stack pointer and grows *towards* the stack base, so shortening it discards the TLS block before it discards any frame. The main thread already keeps its full stack via the enclosing `tid != reader->ProcessID()` check.

### Why 64 KB is safe

The deepest **live** non-main stack I measured across four applications was 12.4 KB, so the cap has ~5x headroom. Verified that a capped thread still walks correctly end to end — `minidump-stackwalk` on a dump whose crashing thread was capped (65,536 B kept of a 113,072 B span):

```
 0  libc.so.6 + 0x9ec0c        <- abort
 1  libc.so.6 + 0x4527d
 2  libc.so.6 + 0x288fe
 3  libstdc++.so.6 + 0xa5a3f   <- std::terminate
 4  libstdc++.so.6 + 0xa5a54
 5  libstdc++.so.6 + 0xbb390
 6  <app> + 0xcb0eae           <- the frame that threw
 7  libstdc++.so.6 + 0xecdb3   <- thread proc
 8  libc.so.6 + 0x9cb83        <- start_thread
```

### Measured effect

| application | threads | before | after |
|---|---|---|---|
| A | 818 | 144.9 MB | 54.0 MB |
| B | 185 | 37.5 MB | 12.4 MB |
| C | 123 | 15.5 MB | 8.2 MB |

Beyond file size this matters for how long a dump takes to write, which is load-bearing when the client is waiting on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)