### PR TITLE
Make --wait-for-upload also wait for a report that is only written

### DIFF
--- a/client/crashpad_client_linux.cc
+++ b/client/crashpad_client_linux.cc
@@ -160,6 +160,9 @@ class SignalHandler {
     last_chance_handler_ = handler;
   }
 
+  // Set from --wait-for-upload, before Install().
+  bool wait_for_report_ = false;
+
   // The base implementation for all signal handlers, suitable for calling
   // directly to simulate signal delivery.
   void HandleCrash(int signo, siginfo_t* siginfo, void* context) {
@@ -228,8 +231,12 @@ class SignalHandler {
      if (handler_->first_chance_handler_ &&
           handler_->first_chance_handler_(
               signo, siginfo, static_cast<ucontext_t*>(context))) {
+        // No dump is coming, so release anyone waiting for one.
+        handler_->WakeThreads();
         return;
       }
+      // A previous first-chance return may have left this signalled.
+      handler_->dump_done_futex_ = kDumpNotDone;
       handler_->HandleCrash(signo, siginfo, context);
       handler_->WakeThreads();
       if (handler_->last_chance_handler_ &&
@@ -262,12 +269,17 @@ class SignalHandler {
     kernel_timespec timeout;
     timeout.tv_sec = 5;
     timeout.tv_nsec = 0;
-    sys_futex(&dump_done_futex_,
-              FUTEX_WAIT_PRIVATE,
-              kDumpNotDone,
-              &timeout,
-              nullptr,
-              0);
+    int rv;
+    do {
+      rv = sys_futex(&dump_done_futex_,
+                     FUTEX_WAIT_PRIVATE,
+                     kDumpNotDone,
+                     wait_for_report_ ? nullptr : &timeout,
+                     nullptr,
+                     0);
+      // FUTEX_WAIT wakes spuriously, so recheck the value, not the return.
+    } while (wait_for_report_ && dump_done_futex_ == kDumpNotDone &&
+             (rv == 0 || errno == EINTR));
   }
 
   void WakeThreads() {
@@ -425,7 +437,8 @@ class RequestCrashDumpHandler : public SignalHandler {
     info.crash_loop_before_time = crash_loop_before_time_;
 #endif
 
-    ExceptionHandlerClient client(sock_to_handler_.get(), true);
+    ExceptionHandlerClient client(
+        sock_to_handler_.get(), true, wait_for_report_);
     client.RequestCrashDump(info);
   }
 
@@ -533,6 +546,7 @@ bool CrashpadClient::StartHandler(
   }
 
   auto signal_handler = RequestCrashDumpHandler::Get();
+  signal_handler->wait_for_report_ = wait_for_upload;
   return signal_handler->Initialize(
       std::move(client_sock), handler_pid, &unhandled_signals_);
 }

--- a/util/linux/exception_handler_client.cc
+++ b/util/linux/exception_handler_client.cc
@@ -17,6 +17,7 @@
 #include <errno.h>
 #include <signal.h>
 #include <sys/prctl.h>
+#include <sys/socket.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -64,11 +65,14 @@ class ScopedSigprocmaskRestore {
 
 }  // namespace
 
-ExceptionHandlerClient::ExceptionHandlerClient(int sock, bool multiple_clients)
+ExceptionHandlerClient::ExceptionHandlerClient(int sock,
+                                               bool multiple_clients,
+                                               bool wait_for_report)
     : server_sock_(sock),
       ptracer_(-1),
       can_set_ptracer_(true),
-      multiple_clients_(multiple_clients) {}
+      multiple_clients_(multiple_clients),
+      wait_for_report_(wait_for_report) {}
 
 ExceptionHandlerClient::~ExceptionHandlerClient() = default;
 
@@ -134,15 +138,24 @@ int ExceptionHandlerClient::SignalCrashDump(
   }
 
   siginfo_t siginfo = {};
-  timespec timeout;
-  timeout.tv_sec = 5;
-  timeout.tv_nsec = 0;
-  if (HANDLE_EINTR(sys_sigtimedwait(&dump_done_sigset, &siginfo, &timeout)) <
-      0) {
-    return errno;
+  timespec timeout = {};
+  timeout.tv_sec = wait_for_report_ ? 1 : 5;
+  for (;;) {
+    if (HANDLE_EINTR(sys_sigtimedwait(&dump_done_sigset, &siginfo, &timeout)) >=
+        0) {
+      return 0;
+    }
+    if (errno != EAGAIN || !wait_for_report_) {
+      return errno;
+    }
+    // Only keep waiting while the handler is still there to signal us.
+    char peek;
+    ssize_t rv =
+        HANDLE_EINTR(recv(server_sock_, &peek, 1, MSG_PEEK | MSG_DONTWAIT));
+    if (rv == 0 || (rv < 0 && errno != EAGAIN)) {
+      return ESRCH;
+    }
   }
-
-  return 0;
 }
 
 int ExceptionHandlerClient::SendCrashDumpRequest(

--- a/util/linux/exception_handler_client.h
+++ b/util/linux/exception_handler_client.h
@@ -30,7 +30,11 @@ class ExceptionHandlerClient {
   //! \param[in] sock A socket connected to an ExceptionHandlerServer.
   //! \param[in] multiple_clients `true` if this socket may be used by multiple
   //!     clients.
-  ExceptionHandlerClient(int sock, bool multiple_clients);
+  //! \param[in] wait_for_report `true` to wait for the handler to finish with
+  //!     the report, rather than giving up after a short timeout.
+  ExceptionHandlerClient(int sock,
+                         bool multiple_clients,
+                         bool wait_for_report = false);
 
   ExceptionHandlerClient(const ExceptionHandlerClient&) = delete;
   ExceptionHandlerClient& operator=(const ExceptionHandlerClient&) = delete;
@@ -89,6 +93,7 @@ class ExceptionHandlerClient {
   pid_t ptracer_;
   bool can_set_ptracer_;
   bool multiple_clients_;
+  bool wait_for_report_;
 };
 
 }  // namespace crashpad


### PR DESCRIPTION
### Problem

`--wait-for-upload` (#121) makes the handler hold the dump-done signal until it has finished with the report, so a client whose process lifetime bounds the handler's — a container's pid 1, a systemd unit — does not exit while the report is still in flight.

The client half was never extended to match. `RequestCrashDumpHandler::HandleCrashImpl` waits for that signal with a hardcoded five second `sigtimedwait` and **discards the result**:

```cpp
ExceptionHandlerClient client(sock_to_handler_.get(), true);
client.RequestCrashDump(info);
```

So once the handler needs longer, the client stops waiting, reraises, and dies anyway. For a pid 1 client the kernel then tears down the pid namespace and SIGKILLs the handler mid-write — losing the whole report, not just its upload. There is no log, and a timed-out wait is indistinguishable from a completed one.

Five seconds is easy to exceed: a few hundred threads writing a minidump to a network filesystem takes tens of seconds, and with a DSN configured the upload is inside the same window.

Linux is also the outlier. The Windows client `SleepEx(INFINITE, false)` after signalling (`crashpad_client_win.cc:176`), the WER path uses `WaitForSingleObject(..., INFINITE)` (`:940`), and macOS uses `kMachMessageTimeoutWaitIndefinitely` (`crashpad_client_mac.cc:502`). Only Linux caps the wait.

### Fix

Plumb `wait_for_upload` through to the client. When it is set:

- `SignalCrashDump` waits for as long as the handler still holds its end of the socket, polling for a peer hangup so a handler that dies without signalling cannot hang the crashing process.
- `WaitForDumpDone`, which any *other* thread taking a fatal signal blocks on, drops its own five second cap. That cap is measured against the dumping thread rather than the handler, so leaving it lets a second crashing thread reraise and tear the process down while the first thread's dump is still being written. It rechecks `dump_done_futex_` rather than the syscall's return value, since `FUTEX_WAIT` is documented to wake spuriously.

Waiters now depend on the dumping thread reaching `WakeThreads()`, and a first-chance handler returning `true` previously returned without getting there, leaving them waiting for a dump that was never coming. They are woken on that path. That was worth fixing anyway — before this change they stalled the full five seconds instead.

Default behaviour is unchanged: without `--wait-for-upload` both waits keep their existing five second timeouts, and the loop guards are false on the first iteration.

### Reproduction

A test app crashing as pid 1 of a container, 8000 threads, minidump written to a bind mount. Same binary throughout; only the option and the number of concurrently crashing threads vary.

| | wall | dump | handler log |
|---|---|---|---|
| without `--wait-for-upload`, one crashing thread | 7.0 s | **none** | 2318 x `ptrace: No such process` |
| without `--wait-for-upload`, plus 4 threads crashing 2 s in | 7.0 s | **none** | 1090 x `ptrace: No such process` |
| with `--wait-for-upload`, one crashing thread | 22.5 s | 915 MB | clean |
| with `--wait-for-upload`, plus 4 threads crashing 2 s in | 23.8 s | 915 MB | clean |

The `ptrace: No such process` flood is the handler still walking threads after the client gave up and the pid namespace went away.

The `WaitForDumpDone` half is load-bearing on its own. With only the `SignalCrashDump` change applied, so waiters still capped at five seconds:

| | wall | dump |
|---|---|---|
| one crashing thread | 25.7 s | 915 MB |
| plus 4 threads crashing 2 s in | 9.5 s | **none** (1035 x `ptrace: No such process`) |

That 9.5 s is startup plus exactly the five second cap.

### Known limits

- A handler that is alive but wedged — blocked in D-state on a stalled network mount — keeps the socket open, so the client keeps waiting. Bounding that needs a timeout, and any constant would be wrong for somebody; happy to add an opt-in cap if you would prefer one.
- A thread that crashes repeatedly inside its own signal handler never returns to `WakeThreads()`, so waiters stay blocked. Previously the five second cap released them and they would reraise and terminate the process. This is the one case where the old cap did something useful that is not replaced here.
- Because the exception server is a single-threaded epoll loop (`exception_handler_server.cc:312`) and `HandleException` runs inline, a long wait for one client also delays service for any other client that crashes in that window. That is pre-existing `--wait-for-upload` behaviour rather than something this change introduces, but it is more visible once the client actually waits.
- `CrashpadClient::SetHandlerSocket()` has no way to express the flag, so a client adopting a handler socket keeps whatever was set by `StartHandler()`.
