### PR TITLE
fix: respect consent for external reporters

### DIFF
--- a/handler/linux/crash_report_exception_handler.cc
+++ b/handler/linux/crash_report_exception_handler.cc
@@ -305,7 +305,9 @@ bool CrashReportExceptionHandler::WriteMinidumpToDatabase(
 
   bool has_crash_reporter = crash_reporter_ && !crash_reporter_->empty() &&
                             crash_envelope_ && !crash_envelope_->empty();
-  if (has_crash_reporter) {
+  bool uploads_enabled = false;
+  database_->GetSettings()->GetUploadsEnabled(&uploads_enabled);
+  if (has_crash_reporter && uploads_enabled) {
     CrashReportDatabase::Envelope envelope(new_report->ReportID());
     if (envelope.Initialize(*crash_envelope_)) {
       envelope.AddAttachments(attachments_);
@@ -327,7 +329,7 @@ bool CrashReportExceptionHandler::WriteMinidumpToDatabase(
     return false;
   }
 
-  if (has_crash_reporter) {
+  if (has_crash_reporter && uploads_enabled) {
     database_->DeleteReport(new_report->ReportID());
   } else if (upload_thread_) {
     upload_thread_->ReportPending(uuid);

--- a/handler/mac/crash_report_exception_handler.cc
+++ b/handler/mac/crash_report_exception_handler.cc
@@ -212,7 +212,9 @@ kern_return_t CrashReportExceptionHandler::CatchMachException(
 
     bool has_crash_reporter = crash_reporter_ && !crash_reporter_->empty() &&
                               crash_envelope_ && !crash_envelope_->empty();
-    if (has_crash_reporter) {
+    bool uploads_enabled = false;
+    settings->GetUploadsEnabled(&uploads_enabled);
+    if (has_crash_reporter && uploads_enabled) {
       CrashReportDatabase::Envelope envelope(new_report->ReportID());
       if (envelope.Initialize(*crash_envelope_)) {
         envelope.AddAttachments(attachments_);
@@ -233,7 +235,7 @@ kern_return_t CrashReportExceptionHandler::CatchMachException(
       return KERN_FAILURE;
     }
 
-    if (has_crash_reporter) {
+    if (has_crash_reporter && uploads_enabled) {
       database_->DeleteReport(uuid);
     } else if (upload_thread_) {
       if (wait_for_upload_) {

--- a/handler/win/crash_report_exception_handler.cc
+++ b/handler/win/crash_report_exception_handler.cc
@@ -168,7 +168,9 @@ unsigned int CrashReportExceptionHandler::ExceptionHandlerServerException(
 
     bool has_crash_reporter = crash_reporter_ && !crash_reporter_->empty() &&
                               crash_envelope_ && !crash_envelope_->empty();
-    if (has_crash_reporter) {
+    bool uploads_enabled = false;
+    settings->GetUploadsEnabled(&uploads_enabled);
+    if (has_crash_reporter && uploads_enabled) {
       CrashReportDatabase::Envelope envelope(new_report->ReportID());
       {
         base::AutoLock scoped_lock(attachments_lock_);
@@ -201,7 +203,7 @@ unsigned int CrashReportExceptionHandler::ExceptionHandlerServerException(
       return termination_code;
     }
 
-    if (has_crash_reporter) {
+    if (has_crash_reporter && uploads_enabled) {
       database_->DeleteReport(uuid);
     } else if (upload_thread_) {
       if (wait_for_upload_) {


### PR DESCRIPTION
Check the database upload setting before launching an external crash reporter. Leave the report pending when consent is revoked (uploads are disabled) so it can be processed later.

See also:
- https://github.com/getsentry/sentry-native/pull/1972
- https://github.com/getsentry/sentry-native/issues/1936