### PR TITLE
fix(win): accept minimal PDB70 CodeView records

### DIFF
--- a/snapshot/win/pe_image_reader.cc
+++ b/snapshot/win/pe_image_reader.cc
@@ -204,7 +204,7 @@ bool PEImageReader::DebugDirectoryInformation(UUID* uuid,
       if (data[data.size() - 1] != '\0') {
         LOG(WARNING) << "CodeView debug entry missing NUL-terminator in "
                      << module_subrange_reader_.name();
-        return false;
+        continue;
       }
 
       CodeViewRecordPDB70* codeview =

--- a/snapshot/win/pe_image_reader.cc
+++ b/snapshot/win/pe_image_reader.cc
@@ -201,6 +201,12 @@ bool PEImageReader::DebugDirectoryInformation(UUID* uuid,
         continue;
       }
 
+      if (data[data.size() - 1] != '\0') {
+        LOG(WARNING) << "CodeView debug entry missing NUL-terminator in "
+                     << module_subrange_reader_.name();
+        return false;
+      }
+
       CodeViewRecordPDB70* codeview =
           reinterpret_cast<CodeViewRecordPDB70*>(data.data());
       *uuid = codeview->uuid;

--- a/snapshot/win/pe_image_reader.cc
+++ b/snapshot/win/pe_image_reader.cc
@@ -177,7 +177,8 @@ bool PEImageReader::DebugDirectoryInformation(UUID* uuid,
       continue;
 
     if (debug_directory.AddressOfRawData) {
-      if (debug_directory.SizeOfData < sizeof(CodeViewRecordPDB70)) {
+      if (debug_directory.SizeOfData <
+          offsetof(CodeViewRecordPDB70, pdb_name) + 1) {
         LOG(WARNING) << "CodeView debug entry of unexpected size in "
                      << module_subrange_reader_.name();
         continue;


### PR DESCRIPTION
Validate the serialized record length instead of the padded C++ struct size so records with an empty PDB filename are accepted.

Tested by:
- https://github.com/getsentry/sentry-native/pull/2003

Original issue:
- https://github.com/getsentry/sentry-native/issues/2002